### PR TITLE
Feature/#90 いいね機能

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,14 @@
+class LikesController < ApplicationController
+  def create
+    @seichi_memo = SeichiMemo.find(params[:seichi_memo_id])
+    current_user.like(@seichi_memo)
+    redirect_to seichi_memo_path(@seichi_memo)
+  end
+
+  def destroy
+    @like = current_user.likes.find(params[:id])
+    seichi_memo = @like.seichi_memo
+    current_user.unlike(seichi_memo)
+    redirect_to seichi_memo_path(seichi_memo), status: :see_other
+  end
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,7 @@
+class Like < ApplicationRecord
+  belongs_to :seichi_memo
+  belongs_to :user
+
+  # 同じ投稿に複数回いいねできないようにする
+  validates :user_id, uniqueness: { scope: :seichi_memo_id, message: "すでにいいねしています" }
+end

--- a/app/models/seichi_memo.rb
+++ b/app/models/seichi_memo.rb
@@ -4,6 +4,7 @@ class SeichiMemo < ApplicationRecord
   belongs_to :place
   has_many :comments, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
+  has_many :likes, dependent: :destroy
 
   mount_uploader :seichi_photo, SeichiPhotoUploader
   mount_uploader :scene_image, SceneImageUploader

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
   has_many :bookmark_seichi_memos, through: :bookmarks, source: :seichi_memo
+  has_many :likes, dependent: :destroy
+  has_many :like_seichi_memos, through: :likes, source: :seichi_memo
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -25,5 +27,18 @@ class User < ApplicationRecord
 
   def bookmark?(seichi_memo)
     bookmark_seichi_memos.include?(seichi_memo)
+  end
+
+  # いいね機能
+  def like(seichi_memo)
+    like_seichi_memos << seichi_memo
+  end
+
+  def unlike(seichi_memo)
+    like_seichi_memos.destroy(seichi_memo)
+  end
+
+  def like?(seichi_memo)  
+    like_seichi_memos.include?(seichi_memo)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ApplicationRecord
     like_seichi_memos.destroy(seichi_memo)
   end
 
-  def like?(seichi_memo)  
+  def like?(seichi_memo)
     like_seichi_memos.include?(seichi_memo)
   end
 end

--- a/app/views/bookmarks/_bookmark.html.erb
+++ b/app/views/bookmarks/_bookmark.html.erb
@@ -1,3 +1,3 @@
-<%= button_to bookmarks_path(seichi_memo_id: seichi_memo.id), method: :post, class: "text-gray-500 hover:text-primary transition-colors text-2xl" do %>
+<%= button_to bookmarks_path(seichi_memo_id: seichi_memo.id), method: :post, class: "text-primary hover:text-primary text-2xl" do %>
   <i class="far fa-bookmark"></i>
 <% end %>

--- a/app/views/bookmarks/_unbookmark.html.erb
+++ b/app/views/bookmarks/_unbookmark.html.erb
@@ -1,3 +1,3 @@
-<%= button_to bookmark_path(bookmark), method: :delete, class: "text-gray-500 hover:text-primary transition-colors text-2xl", data: { turbo_method: :delete } do %>
+<%= button_to bookmark_path(bookmark), method: :delete, class: "text-primary hover:text-primary text-2xl", data: { turbo_method: :delete } do %>
   <i class="fas fa-bookmark"></i>
 <% end %>

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -1,3 +1,3 @@
-<% button_to seichi_memo_likes_path(seichi_memo), method: :post, class: "text-gray-500 hover:text-primary transition-colors text-2xl" do %>
+<%= button_to seichi_memo_likes_path(seichi_memo), method: :post, class: "text-red-500 text-2xl" do %>
   <i class="far fa-heart"></i>
 <% end %>

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -1,0 +1,3 @@
+<% button_to seichi_memo_likes_path(seichi_memo), method: :post, class: "text-gray-500 hover:text-primary transition-colors text-2xl" do %>
+  <i class="far fa-heart"></i>
+<% end %>

--- a/app/views/likes/_like_buttons.html.erb
+++ b/app/views/likes/_like_buttons.html.erb
@@ -1,0 +1,11 @@
+<% if current_user %>
+  <div class="flex items-center space-x-2">
+    <% if current_user && current_user.like?(seichi_memo) %>
+      <%= render 'likes/unlike', seichi_memo: seichi_memo, like: current_user.likes.find_by(seichi_memo: seichi_memo) %>
+    <% else %>
+      <%= render 'likes/like', seichi_memo: seichi_memo %>
+    <% end %>
+    <!-- いいね数の表示 -->
+    <span class="text-sm text-gray-700"><%= seichi_memo.likes.count %></span>
+  </div>
+<% end %>

--- a/app/views/likes/_like_buttons.html.erb
+++ b/app/views/likes/_like_buttons.html.erb
@@ -1,11 +1,17 @@
-<% if current_user %>
-  <div class="flex items-center space-x-2">
-    <% if current_user && current_user.like?(seichi_memo) %>
+<div class="flex items-center space-x-2">
+  <% if current_user %>
+    <% if current_user.like?(seichi_memo) %>
       <%= render 'likes/unlike', seichi_memo: seichi_memo, like: current_user.likes.find_by(seichi_memo: seichi_memo) %>
     <% else %>
       <%= render 'likes/like', seichi_memo: seichi_memo %>
     <% end %>
-    <!-- いいね数の表示 -->
-    <span class="text-sm text-gray-700"><%= seichi_memo.likes.count %></span>
-  </div>
-<% end %>
+  <% else %>
+    <!-- 未ログイン時：押せないハートアイコンだけ表示 -->
+    <div class="text-red-400 text-2xl">
+      <i class="far fa-heart"></i>
+    </div>
+  <% end %>
+
+  <!-- いいね数の表示（共通） -->
+  <span class="text-sm text-gray-700"><%= seichi_memo.likes.count %></span>
+</div>

--- a/app/views/likes/_unlike.html.erb
+++ b/app/views/likes/_unlike.html.erb
@@ -1,3 +1,3 @@
-<%= button_to seichi_memo_likes_path(seichi_memo), method: :delete, class: "text-red-500 text-2xl", data: { turbo_method: :delete } do %>
+<%= button_to like_path(like), method: :delete, class: "text-red-500 text-2xl", data: { turbo_method: :delete } do %>
   <i class="fas fa-heart"></i>
 <% end %>

--- a/app/views/likes/_unlike.html.erb
+++ b/app/views/likes/_unlike.html.erb
@@ -1,3 +1,3 @@
-<%= button_to seichi_memo_likes_path(seichi_memo), method: :delete, class: "text-red-500 hover:text-primary transition-colors text-2xl", data: { turbo_method: :delete } do %>
+<%= button_to seichi_memo_likes_path(seichi_memo), method: :delete, class: "text-red-500 text-2xl", data: { turbo_method: :delete } do %>
   <i class="fas fa-heart"></i>
 <% end %>

--- a/app/views/likes/_unlike.html.erb
+++ b/app/views/likes/_unlike.html.erb
@@ -1,0 +1,3 @@
+<%= button_to seichi_memo_likes_path(seichi_memo), method: :delete, class: "text-red-500 hover:text-primary transition-colors text-2xl", data: { turbo_method: :delete } do %>
+  <i class="fas fa-heart"></i>
+<% end %>

--- a/app/views/seichi_memos/_seichi_memo.html.erb
+++ b/app/views/seichi_memos/_seichi_memo.html.erb
@@ -10,7 +10,11 @@
 
   <!-- コンテンツ -->
   <div class="flex-grow flex flex-col">
-    <h3 class="text-lg font-bold mt-3"><%= seichi_memo.title.truncate(25) %></h3>
+    <div class="flex items-start justify-between mt-3">
+      <h3 class="text-lg font-bold"><%= seichi_memo.title.truncate(25) %></h3>
+      <!-- ブックマークボタン -->
+      <%= render 'bookmarks/bookmark_buttons', seichi_memo: seichi_memo %>
+    </div>
     <p class="text-gray-700"><%= seichi_memo.anime.title %></p>
     <p class="text-gray-600 flex-grow line-clamp-3"><%= seichi_memo.body.truncate(100) %></p>
   </div>
@@ -18,7 +22,7 @@
   <!-- ユーザー情報 -->
   <div class="flex items-center justify-between mt-4 px-2">
     <span class="text-gray-700 text-base font-medium"><%= seichi_memo.user.username %></span>
-    <!-- ブックマークボタン -->
-    <%= render 'bookmarks/bookmark_buttons', seichi_memo: seichi_memo %>
+    <!-- いいねボタン -->
+    <%= render 'likes/like_buttons', seichi_memo: seichi_memo %>
   </div>
 </div>

--- a/app/views/seichi_memos/show.html.erb
+++ b/app/views/seichi_memos/show.html.erb
@@ -47,8 +47,9 @@
     </div>
   </div>
 
-  <!-- アクションボタン -->
-  <div class="flex items-center justify-end mb-2">
+  <!-- アクションボタン(ブックマーク、いいね) -->
+  <div class="flex items-center justify-between mb-2 px-4">
+    <%= render 'likes/like_buttons', seichi_memo: @seichi_memo %>
     <%= render 'bookmarks/bookmark_buttons', seichi_memo: @seichi_memo %>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   # 聖地メモの CRUD ルーティング
   resources :seichi_memos, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     resources :comments, only: %i[create], shallow: true
+    resources :likes, only: %i[create destroy], shallow: true
     collection do
       match :update_session, via: [ :post, :patch ] # ステップごとのデータをセッションに保存
       get :prepare_confirm # 確認画面でセッション情報を反映する

--- a/db/migrate/20250418223139_create_likes.rb
+++ b/db/migrate/20250418223139_create_likes.rb
@@ -1,0 +1,11 @@
+class CreateLikes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :likes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :seichi_memo, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :likes, [ :user_id, :seichi_memo_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_16_205445) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_18_223139) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,6 +41,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_16_205445) do
     t.datetime "updated_at", null: false
     t.index ["seichi_memo_id"], name: "index_comments_on_seichi_memo_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "likes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "seichi_memo_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["seichi_memo_id"], name: "index_likes_on_seichi_memo_id"
+    t.index ["user_id", "seichi_memo_id"], name: "index_likes_on_user_id_and_seichi_memo_id", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
   create_table "places", force: :cascade do |t|
@@ -85,6 +95,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_16_205445) do
   add_foreign_key "bookmarks", "users"
   add_foreign_key "comments", "seichi_memos"
   add_foreign_key "comments", "users"
+  add_foreign_key "likes", "seichi_memos"
+  add_foreign_key "likes", "users"
   add_foreign_key "seichi_memos", "animes"
   add_foreign_key "seichi_memos", "places"
   add_foreign_key "seichi_memos", "users"


### PR DESCRIPTION
## 概要
聖地メモ一覧画面や詳細画面に表示するいいねボタン「♡」を押すといいねすることができる
同じユーザーは同じ対象に複数回「いいね」できない
ログインユーザーのみ「いいね」可能
→未ログイン時はいいねボタンを非表示にする

いいね数のカウントを表示
→対象ごとに現在の「いいね数」を表示する

いいねする前「♡」いいねした後「♥」でいいねボタンのUI表示を変更していいねした投稿がわかるようにする
## 実施内容
![image](https://github.com/user-attachments/assets/ff74cf0e-bb70-49f8-8ee3-df40e9844391)

## 関連issue
#90  いいね機能