### PR TITLE
Feature/#92 コメント機能のajax化

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,29 +1,29 @@
 class CommentsController < ApplicationController
+  before_action :authenticate_user!
+
   def create
     @seichi_memo = SeichiMemo.includes(:anime, :place).find(params[:seichi_memo_id])
     @comment = @seichi_memo.comments.build(comment_params)
-    @comment.user = current_user # 現在のユーザーをコメントの作成者として設定
+    @comment.user = current_user
 
     if @comment.save
       respond_to do |format|
-        format.turbo_stream
-        format.html { redirect_to seichi_memo_path(@seichi_memo), notice: "コメントを投稿しました" }
+        format.turbo_stream do 
+          flash.now[:comment_notice] = "コメントを投稿しました。"
+          render :create
+        end
+        format.html { redirect_to seichi_memo_path(@seichi_memo),  flash: { comment_notice: "コメントを投稿しました。" } }
       end
     else
       @comments = @seichi_memo.comments.includes(:user)
       respond_to do |format|
         format.turbo_stream do
-          flash.now[:alert] = "コメントを投稿出来ませんでした"
-          render turbo_stream: turbo_stream.replace(
-            "comment_form",
-            partial: "comments/form",
-            locals: { seichi_memo: @seichi_memo, comment: @comment }
-          )
+          flash.now[:comment_alert] = "コメントを投稿出来ませんでした"
+          render turbo_stream: [
+            turbo_stream.replace("flash", partial: "shared/flash_message_turbo")
+          ]
         end
-        format.html do
-          flash.now[:alert] = "コメントを投稿出来ませんでした"
-          render "seichi_memos/show", status: :unprocessable_entity
-        end
+        format.html { redirect_to seichi_memo_path(@seichi_memo), flash: { comment_alert: "コメントを投稿出来ませんでした" } }
       end
     end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -8,7 +8,7 @@ class CommentsController < ApplicationController
 
     if @comment.save
       respond_to do |format|
-        format.turbo_stream do 
+        format.turbo_stream do
           flash.now[:comment_notice] = "コメントを投稿しました。"
           render :create
         end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,8 +2,8 @@ module ApplicationHelper
   # フラッシュメッセージの背景色を変更
   def flash_background_color(type)
     case type.to_sym
-    when :notice then "bg-green-500"  # 成功（緑）
-    when :alert  then "bg-red-500"    # 失敗（赤）
+    when :notice, :comment_notice then "bg-green-500"  # 成功（緑）
+    when :alert, :comment_alert  then "bg-red-500"    # 失敗（赤）
     when :warning then "bg-yellow-500" # 警告（黄）
     when :info   then "bg-blue-500"   # 情報（青）
     else "bg-gray-500"

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
-<div class="space-y-2 mb-4">
+<div id="comments" class="space-y-2 mb-4">
   <% if comments.any? %>
     <% comments.each do |comment| %>
       <div class="flex items-start space-x-3">

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,13 +1,15 @@
 <% if user_signed_in? %>
-  <%= form_with model: [seichi_memo, comment], local: true, class: "flex-grow" do |f| %>
-    <div class="bg-gray-100 rounded shadow-sm mb-2">
-      <%= f.text_area :content, placeholder: "コメントする", class: "w-full bg-transparent text-sm border-none focus:outline-none px-3 py-1" %>
-    </div>
+  <div id="comment_form">
+    <%= form_with model: [seichi_memo, comment], local: true, class: "flex-grow" do |f| %>
+      <div class="bg-gray-100 rounded shadow-sm mb-2">
+        <%= f.text_area :content, placeholder: "コメントする", class: "w-full bg-transparent text-sm border-none focus:outline-none px-3 py-1" %>
+      </div>
 
-    <div class="text-right">
-      <%= f.submit "コメント", class: "btn btn-primary" %>
-    </div>
-  <% end %>
+      <div class="text-right">
+        <%= f.submit "コメント", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+  </div>
 <% else %> 
   <div class="text-center mb-4 p-4 border rounded-md text-gray-700">
     コメントを投稿するには

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.prepend "comments", partial: "comments/comment", locals: { comments: [@comment] } %>
+
+<%= turbo_stream.replace "comment_form", partial: "comments/form", locals: { seichi_memo: @seichi_memo, comment: Comment.new } %>
+
+<%= turbo_stream.update "comments_count" do %><%= @seichi_memo.comments.count %>件のコメント<% end %>
+
+<%= turbo_stream.replace "flash", partial: "shared/flash_message_turbo" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,9 @@
 
   <body class="bg-gray-100 min-h-screen flex flex-col">
   <%= render 'shared/header' %>
-  <%= render 'layouts/flash_messages' %>
+  <div id="flash">
+    <%= render 'layouts/flash_messages' %>
+  </div>
   <!-- Main Content -->
   <main class="flex-grow container mx-auto px-4 py-8">
     <%= yield %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,9 +23,7 @@
 
   <body class="bg-gray-100 min-h-screen flex flex-col">
   <%= render 'shared/header' %>
-  <div id="flash">
-    <%= render 'layouts/flash_messages' %>
-  </div>
+  <%= render 'layouts/flash_messages' %>
   <!-- Main Content -->
   <main class="flex-grow container mx-auto px-4 py-8">
     <%= yield %>

--- a/app/views/seichi_memos/show.html.erb
+++ b/app/views/seichi_memos/show.html.erb
@@ -105,6 +105,11 @@
     <!-- コメント件数表示 -->
     <h2 id="comments_count" class="text-base text-black font-semibold mb-3"><%= @comments.count %>件のコメント</h2>
 
+    <!-- フラッシュメッセージ -->
+    <div id="flash" class="mb-5">
+      <%= render "shared/flash_message_turbo" %>
+    </div>
+
     <!-- コメントフォーム -->
     <%= render partial: "comments/form", locals: { seichi_memo: @seichi_memo, comment: @comment } %>
 

--- a/app/views/seichi_memos/show.html.erb
+++ b/app/views/seichi_memos/show.html.erb
@@ -103,7 +103,7 @@
   <!-- コメントセクション -->
   <div class="border-t border-gray-300 p-4">
     <!-- コメント件数表示 -->
-    <h2 class="text-base text-black font-semibold mb-3"><%= @comments.count %>件のコメント</h2>
+    <h2 id="comments_count" class="text-base text-black font-semibold mb-3"><%= @comments.count %>件のコメント</h2>
 
     <!-- コメントフォーム -->
     <%= render partial: "comments/form", locals: { seichi_memo: @seichi_memo, comment: @comment } %>

--- a/app/views/shared/_flash_message_turbo.html.erb
+++ b/app/views/shared/_flash_message_turbo.html.erb
@@ -1,0 +1,22 @@
+<div id="flash_message" class="<%= flash[:comment_notice] || flash[:comment_alert] ? '' : 'hidden' %> fixed top-5 right-5 w-96 z-50 space-y-3">
+  <% if flash[:comment_notice] || flash[:comment_alert] %>
+    <% { comment_notice: "blue", comment_alert: "red" }.each do |key, color| %>
+      <% if flash[key] %>
+        <div class="<%= flash_background_color(key) %> px-4 py-3 rounded-md text-white flex items-center shadow-lg animate-slide-in fade-out" id="flash-message-<%= key %>">
+          <span class="ml-3"><%= flash[key] %></span>
+        <button onclick="this.parentElement.remove();" class="ml-auto text-xl leading-none">&times;</button>
+        </div>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <script>
+    // 5秒後にフェードアウトさせて削除
+    setTimeout(() => {
+      document.querySelectorAll('.fade-out').forEach(el => {
+        el.classList.add('animate-fade-out');
+        setTimeout(() => el.remove(), 500);
+      });
+    }, 5000);
+  </script>
+</div>


### PR DESCRIPTION
## 概要

`Comments`コントローラーの`create`アクションのTurboリクエストに対応させる

コメントの作成で実現したいこと：

①コメント件数の更新
②コメントフォームを空にする
③追加したコメントを一覧表示の一番上に表示する
④フラッシュメッセージをページ上に表示する
## 実施内容
![image](https://github.com/user-attachments/assets/98ad9a6a-378c-457e-bbaf-6d6a9cfbbac3)


## 関連issue
#92 コメント機能のajax化