### PR TITLE
Feature/#104 投稿の聖地情報のgoogle mapsへの遷移機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ gem "kaminari"
 # .envファイルで環境変数を管理
 gem "dotenv-rails"
 
+# Geocoding
+gem "geocoder"
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.1"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
+    csv (3.3.4)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
@@ -152,6 +153,9 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.1.0)
+    geocoder (1.8.5)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -405,6 +409,7 @@ DEPENDENCIES
   dotenv-rails
   faker
   fog-aws
+  geocoder
   jbuilder
   jsbundling-rails
   kaminari

--- a/app/forms/seichi_memo_form.rb
+++ b/app/forms/seichi_memo_form.rb
@@ -113,10 +113,9 @@ class SeichiMemoForm
 
     # 🔹 既存の聖地情報を取得 or 作成
     place = Place.find_or_create_by(name: place_name)
-    place.update(
-      address: place_address.presence || place.address,
-      postal_code: place_postal_code.presence || place.postal_code
-    )
+    place.address = place_address.presence || place.address
+    place.postal_code = place_postal_code.presence || place.postal_code
+    place.save!
 
     # 🔹 聖地メモを作成
     @seichi_memo = SeichiMemo.create!(
@@ -145,10 +144,9 @@ class SeichiMemoForm
 
     # 🔹 既存の聖地情報を更新
     place = Place.find_or_create_by(name: place_name)
-    place.update(
-      address: place_address.presence || place.address,
-      postal_code: place_postal_code.presence || place.postal_code
-    )
+    place.address = place_address.presence || place.address
+    place.postal_code = place_postal_code.presence || place.postal_code
+    place.save!
 
     # 🔹 聖地メモの情報を更新
     seichi_memo.update(

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -1,3 +1,7 @@
 class Place < ApplicationRecord
   has_many :seichi_memos, dependent: :destroy
+
+  # geocodingについての設定
+  geocoded_by :address
+  after_validation :geocode, if: :address_changed?
 end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -3,5 +3,5 @@ class Place < ApplicationRecord
 
   # geocodingについての設定
   geocoded_by :address
-  after_validation :geocode, if: :address_changed?
+  after_validation :geocode
 end

--- a/app/views/seichi_memos/show.html.erb
+++ b/app/views/seichi_memos/show.html.erb
@@ -123,8 +123,9 @@
     <%= render partial: "comments/comment", locals: { comments: @comments } %>
   </div>
 
-  <!-- 戻るボタン -->
-  <div class="mt-6 text-center">
-    <%= link_to "みんなの投稿に戻る", seichi_memos_path, class: "bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-6 rounded-lg shadow-md transition duration-200 text-center" %>
+  <!-- ボタンエリア -->
+  <div class="flex flex-col items-center space-y-4 mt-8">
+    <%= link_to "ここへ行く", "https://www.google.com/maps/dir/?api=1&destination=#{@seichi_memo.place.latitude},#{@seichi_memo.place.longitude}", target: "_blank", class: "btn bg-primary hover:bg-primary-dark text-white font-bold py-2 px-6 rounded-lg shadow-md transition duration-200  w-full max-w-xs" %>
+    <%= link_to "みんなの投稿に戻る", seichi_memos_path, class: "bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-6 rounded-lg shadow-md transition duration-200 w-full max-w-xs text-center" %>
   </div>
 </div>

--- a/app/views/seichi_memos/show.html.erb
+++ b/app/views/seichi_memos/show.html.erb
@@ -5,14 +5,14 @@
 
     <% if current_user == @seichi_memo.user %>
       <div class="flex space-x-2">
-        <%= link_to edit_seichi_memo_path(@seichi_memo), class: "btn btn-primary flex items-center space-x-1" do %>
+        <%= link_to edit_seichi_memo_path(@seichi_memo), class: "btn bg-primary text-white flex items-center space-x-1" do %>
           <i class="fas fa-pen"></i>
           <span>編集</span>
         <% end %>
 
         <%= link_to seichi_memo_path(@seichi_memo),
                     data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' },
-                    class: "btn btn-primary flex items-center space-x-1" do %>
+                    class: "btn bg-primary text-white flex items-center space-x-1" do %>
           <i class="fas fa-trash-alt"></i>
           <span>削除</span>
         <% end %>
@@ -125,7 +125,7 @@
 
   <!-- ボタンエリア -->
   <div class="flex flex-col items-center space-y-4 mt-8">
-    <%= link_to "ここへ行く", "https://www.google.com/maps/dir/?api=1&destination=#{@seichi_memo.place.latitude},#{@seichi_memo.place.longitude}", target: "_blank", class: "btn bg-primary hover:bg-primary-dark text-white font-bold py-2 px-6 rounded-lg shadow-md transition duration-200  w-full max-w-xs" %>
+  <%= link_to "ここへ行く", "https://www.google.com/maps/search/?api=1&query=#{CGI.escape(@seichi_memo.place.name + ' ' + @seichi_memo.place.address)}", target: "_blank", class: "btn bg-primary hover:bg-primary-dark text-white font-bold py-2 px-6 rounded-lg shadow-md transition duration-200  w-full max-w-xs" %>
     <%= link_to "みんなの投稿に戻る", seichi_memos_path, class: "bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-6 rounded-lg shadow-md transition duration-200 w-full max-w-xs text-center" %>
   </div>
 </div>

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  lookup: :google,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  use_https: true,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  api_key: ENV["GOOGLE_PLACES_API_KEY"],               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)

--- a/db/migrate/20250502013322_add_latitude_and_longitude_to_places.rb
+++ b/db/migrate/20250502013322_add_latitude_and_longitude_to_places.rb
@@ -1,0 +1,6 @@
+class AddLatitudeAndLongitudeToPlaces < ActiveRecord::Migration[7.2]
+  def change
+    add_column :places, :latitude, :float
+    add_column :places, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_23_074814) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_02_013322) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -59,6 +59,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_23_074814) do
     t.string "postal_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.float "latitude"
+    t.float "longitude"
     t.index ["name"], name: "index_places_on_name", unique: true
   end
 


### PR DESCRIPTION
## 概要
投稿詳細画面にその投稿の聖地に関するGoogleMapsの詳細画面に遷移するリンクを設置して、そのリンクを踏むとGoogleMapsに遷移するようにする

遷移リンクは投稿詳細画面のページ下部に上に遷移リンク、下に一覧ページへ戻るボタンという配置にする。また遷移リンクは「ここへ行く」と言うテキストを表示すること。

タスク
## 実施内容
![image](https://github.com/user-attachments/assets/26f92b50-72c4-478d-b4b8-59f72ee9fdbb)

## 関連issue
#104  投稿の聖地情報のgoogle mapsへの遷移機能