### PR TITLE
Fix/google mapsのリンク生成時にnilで発生する不具合の修正

### DIFF
--- a/app/views/seichi_memos/show.html.erb
+++ b/app/views/seichi_memos/show.html.erb
@@ -125,7 +125,7 @@
 
   <!-- ボタンエリア -->
   <div class="flex flex-col items-center space-y-4 mt-8">
-  <%= link_to "ここへ行く", "https://www.google.com/maps/search/?api=1&query=#{CGI.escape(@seichi_memo.place.name + ' ' + @seichi_memo.place.address)}", target: "_blank", class: "btn bg-primary hover:bg-primary-dark text-white font-bold py-2 px-6 rounded-lg shadow-md transition duration-200  w-full max-w-xs" %>
+  <%= link_to "ここへ行く", "https://www.google.com/maps/search/?api=1&query=#{CGI.escape(@seichi_memo.place.name.to_s + ' ' + @seichi_memo.place.address.to_s)}", target: "_blank", class: "btn bg-primary hover:bg-primary-dark text-white font-bold py-2 px-6 rounded-lg shadow-md transition duration-200  w-full max-w-xs" %>
     <%= link_to "みんなの投稿に戻る", seichi_memos_path, class: "bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-6 rounded-lg shadow-md transition duration-200 w-full max-w-xs text-center" %>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -96,7 +96,7 @@
           <li><%= link_to 'お問い合わせ', "#", class: "btn btn-ghost justify-start w-full text-left text-white-700 hover:bg-gray-300 hover:shadow-md rounded-md" %></li>
 
           <hr class="border-gray-200">
-          <li class="text-center text-xs mt-2 text-white-500">&copy; 2025 Animeguru</li>
+          <li class="text-center text-xs mt-2 text-white-500">Copyright &copy; 2025 Animeguru</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## 概要
Google Mapsのリンク生成時に、placeのnameまたはaddressがnilである場合にエラー（TypeError）が発生していた問題を修正。
## 実施内容
- `@seichi_memo.place.name` および `address` に対して `.to_s` を使用し、nilの場合でも空文字列として扱うよう修正
- `CGI.escape(...)` の引数内で `nil + String` が起こらないよう安全対策を実装
- 該当箇所は `seichi_memos/show.html.erb`
## 関連issue
なし