### PR TITLE
Feature/#111 作品ジャンルの検索機能

### DIFF
--- a/app/controllers/seichi_memos_controller.rb
+++ b/app/controllers/seichi_memos_controller.rb
@@ -8,6 +8,7 @@ class SeichiMemosController < ApplicationController
   def index
     @q = SeichiMemo.ransack(params[:q])
     @seichi_memos = @q.result(distinct: true).includes(:anime, :place, :user, :genre_tags).order(created_at: :desc).page(params[:page]).per(18)
+    @jenre_tags = GenreTag.all
   end
 
   def show
@@ -95,6 +96,7 @@ class SeichiMemosController < ApplicationController
   def bookmarks
     @q = current_user.bookmark_seichi_memos.ransack(params[:q])
     @bookmark_seichi_memos = @q.result(distinct: true).includes(:anime, :place, :genre_tags).order(created_at: :desc).page(params[:page]).per(18)
+    @jenre_tags = GenreTag.all
   end
 
   private

--- a/app/models/genre_tag.rb
+++ b/app/models/genre_tag.rb
@@ -4,12 +4,12 @@ class GenreTag < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
 
-  #ransackで許可するカラムを指定
+  # ransackで許可するカラムを指定
   def self.ransackable_attributes(auth_object = nil)
     %w[name]
   end
 
-  #ransackで許可するテーブルを指定
+  # ransackで許可するテーブルを指定
   def self.ransackable_associations(auth_object = nil)
     %w[seichi_memos]
   end

--- a/app/models/genre_tag.rb
+++ b/app/models/genre_tag.rb
@@ -3,4 +3,14 @@ class GenreTag < ApplicationRecord
   has_many :seichi_memos, through: :taggings
 
   validates :name, presence: true, uniqueness: true
+
+  #ransackで許可するカラムを指定
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name]
+  end
+
+  #ransackで許可するテーブルを指定
+  def self.ransackable_associations(auth_object = nil)
+    %w[seichi_memos]
+  end
 end

--- a/app/models/seichi_memo.rb
+++ b/app/models/seichi_memo.rb
@@ -17,6 +17,6 @@ class SeichiMemo < ApplicationRecord
   end
 
   def self.ransackable_associations(auth_object = nil)
-    %w[anime place]
+    %w[anime place genre_tags]
   end
 end

--- a/app/views/seichi_memos/_search_form.html.erb
+++ b/app/views/seichi_memos/_search_form.html.erb
@@ -1,8 +1,13 @@
-<%= search_form_for @q, url: search_url, method: :get, class: "mb-4" do |f| %>
+<%= search_form_for @q, url: search_url, method: :get, class: "mb-6" do |f| %>
   <div class="flex justify-center">
-    <div class="flex space-x-2 w-full max-w-xl">
+    <div class="flex space-x-4 w-full max-w-3xl">
+      <!-- 聖地名・作品タイトル検索 -->
       <%= f.search_field :place_name_or_anime_title_cont, placeholder: "検索ワードを入力（聖地名・作品タイトル）", class: "w-full p-3 border border-gray-300 rounded-md shadow-sm" %>
 
+      <!-- ジャンルタグ検索 -->
+      <%= f.select :genre_tags_name_eq, options_for_select(GenreTag.all.map { |tag| [tag.name, tag.name] }, selected: params.dig(:q, :genre_tags_name_eq)), { include_blank: "ジャンルを選択" }, class: "w-1/3 p-3 border border-gray-300 rounded-md shadow-sm" %>
+      
+      <!-- 検索ボタン -->
       <%= f.submit class: "btn bg-primary text-white px-4 py-2 shadow-md transition duration-200 flex items-center justify-center" do %>
         <i class="fas fa-search"></i>
       <% end %>

--- a/app/views/seichi_memos/_seichi_memo.html.erb
+++ b/app/views/seichi_memos/_seichi_memo.html.erb
@@ -16,16 +16,26 @@
       <%= render 'bookmarks/bookmark_buttons', seichi_memo: seichi_memo %>
     </div>
     <h3 class="font-bold"><%= seichi_memo.anime.title %></h3>
+
     <!-- 作品ジャンル -->
     <% if seichi_memo.genre_tags.present? %>
       <div class="flex flex-wrap gap-2 mt-2">
         <% seichi_memo.genre_tags.each do |genre_tag| %>
-          <span class="bg-primary text-gray-700 text-xs font-medium px-2 py-0.5 rounded-full">
-            <%= genre_tag.name %>
-          </span>
+          <% if current_user.bookmark?(seichi_memo) %>
+            <%= link_to bookmarks_seichi_memos_path(current_user, q: { genre_tags_name_eq: genre_tag.name }), 
+                        class: "bg-primary text-gray-700 text-xs font-medium px-2 py-0.5 rounded-full hover:bg-secondary" do %>
+              <%= genre_tag.name %>
+            <% end %>
+          <% else %>
+            <%= link_to seichi_memos_path(q: { genre_tags_name_eq: genre_tag.name }), 
+                        class: "bg-primary text-gray-700 text-xs font-medium px-2 py-0.5 rounded-full hover:bg-secondary" do %>
+              <%= genre_tag.name %>
+            <% end %>
+          <% end %>
         <% end %>
       </div>
     <% end %>
+
     <p class="text-gray-600 line-clamp-3 mt-2"><%= seichi_memo.body.truncate(100) %></p>
   </div>
 

--- a/app/views/seichi_memos/show.html.erb
+++ b/app/views/seichi_memos/show.html.erb
@@ -61,9 +61,17 @@
   <% if @seichi_memo.genre_tags.present? %>
     <div class="flex flex-wrap gap-2 mt-2">
       <% @seichi_memo.genre_tags.each do |genre_tag| %>
-        <span class="bg-primary text-gray-700 text-sm font-semibold px-3 py-1 rounded-full">
-          <%= genre_tag.name %>
-        </span>
+        <% if current_user.bookmark?(@seichi_memo) %>
+          <%= link_to bookmarks_seichi_memos_path(current_user, q: { genre_tags_name_eq: genre_tag.name }), 
+                      class: "bg-primary text-gray-700 text-xs font-medium px-2 py-0.5 rounded-full hover:bg-secondary" do %>
+            <%= genre_tag.name %>
+          <% end %>
+        <% else %>
+          <%= link_to seichi_memos_path(q: { genre_tags_name_eq: genre_tag.name }), 
+                      class: "bg-primary text-gray-700 text-xs font-medium px-2 py-0.5 rounded-full hover:bg-secondary" do %>
+            <%= genre_tag.name %>
+          <% end %>
+        <% end %>
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION
## 概要
ransackを用いて以下の検索機能を実装する

genre_tagsモデルに登録されている作成ジャンルごとに聖地メモを絞り込み検索することができる
聖地メモ一覧画面にドロップダウンメニュー形式でジャンルタグ検索を実装する
ブックマークした投稿一覧にドロップダウンメニュー形式でジャンルタグ検索を実装する
聖地メモカードや詳細画面で表示しているジャンルタグをクリックすると一覧画面に遷移してそのジャンルタグを選択している投稿の検索結果を表示する
## 実施内容
![image](https://github.com/user-attachments/assets/b093253f-7e42-488f-95f2-f45b74284f21)

## 関連issue
#111 