### PR TITLE
Fix/パスワード再設定リンクのエラー修正

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,12 +42,16 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
-
-  # :letter_opener_web を使って、メールを実際に送信せずブラウザで確認する
-  config.action_mailer.delivery_method = :letter_opener_web
-
-  # メール処理を実行する（false にするとメール生成自体をスキップする）
-  config.action_mailer.perform_deliveries = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    domain: "smtp.gmail.com",
+    port: 587,
+    user_name: ENV["MAILER_SENDER"],
+    password: ENV["MAILER_PASSWORD"],
+    authentication: :login,
+    enable_starttls_auto: true
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,6 +81,19 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default_url_options = { host: "https://animeguru.onrender.com" }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    domain: "smtp.gmail.com",
+    port: 587,
+    user_name: ENV["MAILER_SENDER"],
+    password: ENV["MAILER_PASSWORD"],
+    authentication: :login,
+    enable_starttls_auto: true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = ENV['MAILER_SENDER']
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV['MAILER_SENDER']
+  config.mailer_sender = ENV["MAILER_SENDER"]
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -26,6 +26,9 @@ ja:
     passwords:
       send_instructions: "パスワード再設定の手順を数分以内にメールで送信します"
       updated: "パスワードを再設定しました"
+    mailer:
+      reset_password_instructions:
+        subject: "パスワード再設定のご案内"
     failure:
       already_authenticated: "すでにログインしています"
       unauthenticated: "ログインが必要です"


### PR DESCRIPTION
## 概要
本番環境でリセットパスワードのメール送信時にgmailの設定やホスト名を指定していなかかったため別ブランチで設定を行った
## 実施内容
- [x]  `config/environments/production.rb` にホスト名を指定する設定を追加する
- [x]  アプリ用のGoogleアカウント作成して二段階認証とアプリパスワードを生成する
- [x]  環境変数にアプリ用のメアドとアプリパスワードを設定する
- [x]  `config/environments/production.rb` にgmailの設定を追加する
- [x]  `config/environments/development.rb` にgmailの設定を追加する
- [x]  Deviseの設定ファイル（`config/initializers/devise.rb`）で、メール送信者を設定する
## 関連issue