### PR TITLE
favicon_link_tagから<link>タグに変更し、public配下のアイコン画像を確実に参照できるよう修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
     <link rel="manifest" href="/manifest.json">
     <%= favicon_link_tag 'favicon.ico' %>
     <%= favicon_link_tag 'apple-touch-icon.png', rel: 'apple-touch-icon', type: 'image/png', sizes: '180x180' %>
-    <%= favicon_link_tag 'android-chrome-192x192.png', rel: 'icon', type: 'image/png', sizes: '192x192' %>
+    <link rel="icon" href="/android-chrome-192x192.png" sizes="192x192" type="image/png">
     <%= favicon_link_tag 'android-chrome-512x512.png', rel: 'icon', type: 'image/png', sizes: '512x512' %>
 
     <!-- Stylesheets -->


### PR DESCRIPTION
## 概要
favicon_link_tagから<link>タグに変更し、public配下のアイコン画像を確実に参照できるよう修正
## 実施内容

## 関連issue