### PR TITLE
favicon_link_tagを<link>タグに置き換えてandroid-chrome-512x512.pngを正しく参照できるよう修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,8 +27,8 @@
     <link rel="manifest" href="/manifest.json">
     <%= favicon_link_tag 'favicon.ico' %>
     <%= favicon_link_tag 'apple-touch-icon.png', rel: 'apple-touch-icon', type: 'image/png', sizes: '180x180' %>
-    <link rel="icon" href="/android-chrome-192x192.png" sizes="192x192" type="image/png">
-    <%= favicon_link_tag 'android-chrome-512x512.png', rel: 'icon', type: 'image/png', sizes: '512x512' %>
+    <link rel="icon" href="/android-chrome-192x192.png" type="image/png" sizes="192x192">
+    <link rel="icon" href="/android-chrome-512x512.png" type="image/png" sizes="512x512">
 
     <!-- Stylesheets -->
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>


### PR DESCRIPTION
## 概要
favicon_link_tagを<link>タグに置き換えてandroid-chrome-512x512.pngを正しく参照できるよう修正
## 実施内容

## 関連issue