### PR TITLE
Feature/#153 画像選択時にajaxで画像だけをサーバーに送ってキャッシュ名を受け取る処理

### DIFF
--- a/app/controllers/seichi_memos_controller.rb
+++ b/app/controllers/seichi_memos_controller.rb
@@ -154,6 +154,9 @@ class SeichiMemosController < ApplicationController
       :place_postal_code,
       :seichi_photo,
       :scene_image,
+      :seichi_photo_cache,
+      :scene_image_cache,
+      :image_url_cache, 
       genre_tag_ids: []
     ).merge(user_id: current_user.id)
   end

--- a/app/controllers/seichi_memos_controller.rb
+++ b/app/controllers/seichi_memos_controller.rb
@@ -156,7 +156,7 @@ class SeichiMemosController < ApplicationController
       :scene_image,
       :seichi_photo_cache,
       :scene_image_cache,
-      :image_url_cache, 
+      :image_url_cache,
       genre_tag_ids: []
     ).merge(user_id: current_user.id)
   end

--- a/app/controllers/seichi_memos_controller.rb
+++ b/app/controllers/seichi_memos_controller.rb
@@ -127,6 +127,18 @@ class SeichiMemosController < ApplicationController
     render json: places + animes
   end
 
+  # アップロードされた画像ファイルを一時キャッシュしてキャッシュ名を返す
+  def upload_image
+    uploader = {
+      "seichi_photo" => SeichiPhotoUploader,
+      "scene_image"  => SceneImageUploader,
+      "image_url"    => AnimeImageUploader
+    }[params[:type]]&.new or return head :bad_request
+
+    uploader.cache!(params[:file])
+    render json: { cache_name: uploader.cache_name }
+  end
+
   private
 
   # 🔹 Strong Parameters

--- a/app/forms/seichi_memo_form.rb
+++ b/app/forms/seichi_memo_form.rb
@@ -74,7 +74,7 @@ class SeichiMemoForm
     end
   end
 
-    # 🔹 現在のフォーム入力内容をセッションに保存するメソッド
+  # 🔹 現在のフォーム入力内容をセッションに保存するメソッド
   def save_to_session(session)
     session[:seichi_memo] ||= {}
     session[:seichi_memo].merge!(attributes.except("seichi_photo", "scene_image", "image_url"))

--- a/app/forms/seichi_memo_form.rb
+++ b/app/forms/seichi_memo_form.rb
@@ -74,32 +74,15 @@ class SeichiMemoForm
     end
   end
 
-  # 🔹 現在のフォーム入力内容をセッションに保存するメソッド
+    # 🔹 現在のフォーム入力内容をセッションに保存するメソッド
   def save_to_session(session)
     session[:seichi_memo] ||= {}
     session[:seichi_memo].merge!(attributes.except("seichi_photo", "scene_image", "image_url"))
 
-    case current_step
-    when "memo"
-      if seichi_photo.present? && (!editing? || seichi_photo_changed?)
-        uploader = SeichiPhotoUploader.new
-        uploader.cache!(seichi_photo)
-        session[:seichi_memo]["seichi_photo_cache"] = uploader.cache_name
-      end
-
-      if scene_image.present? && (!editing? || scene_image_changed?)
-        uploader = SceneImageUploader.new
-        uploader.cache!(scene_image)
-        session[:seichi_memo]["scene_image_cache"] = uploader.cache_name
-      end
-
-    when "anime"
-      if image_url.present? && (!editing? || image_url_changed?)
-        uploader = AnimeImageUploader.new
-        uploader.cache!(image_url)
-        session[:seichi_memo]["image_url_cache"] = uploader.cache_name
-      end
-    end
+    # キャッシュ名があればセッションに直接保存
+    session[:seichi_memo]["seichi_photo_cache"] = seichi_photo_cache if seichi_photo_cache.present?
+    session[:seichi_memo]["scene_image_cache"]  = scene_image_cache  if scene_image_cache.present?
+    session[:seichi_memo]["image_url_cache"]    = image_url_cache    if image_url_cache.present?
   end
 
     # 🔹 最終ステップでデータベースに保存

--- a/app/javascript/controllers/image_upload_controller.js
+++ b/app/javascript/controllers/image_upload_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="image-upload"
+export default class extends Controller {
+  static targets = ["input", "cacheField"]
+  static values = { type: String }
+
+  upload() {
+    const file = this.inputTarget.files[0]
+    if (!file) return
+
+    const formData = new FormData()
+    formData.append("file", file)
+    formData.append("type", this.typeValue)
+
+    fetch("/seichi_memos/upload_image", {
+      method: "POST",
+      headers: {
+        "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
+      },
+      body: formData
+    })
+      .then(response => {
+        if (!response.ok) throw new Error("Upload failed")
+        return response.json()
+      })
+      .then(data => {
+        this.cacheFieldTarget.value = data.cache_name
+      })
+      .catch(error => {
+        console.error("画像アップロードに失敗しました:", error)
+      })
+  }
+}

--- a/app/javascript/controllers/image_upload_controller.js
+++ b/app/javascript/controllers/image_upload_controller.js
@@ -5,6 +5,10 @@ export default class extends Controller {
   static targets = ["input", "cacheField"]
   static values = { type: String }
 
+  connect() {
+    console.log("📸 image-uploadが接続された")
+  }
+
   upload() {
     const file = this.inputTarget.files[0]
     if (!file) return

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -16,6 +16,9 @@ application.register("genre-modal", GenreModalController)
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import ImageUploadController from "./image_upload_controller"
+application.register("image-upload", ImageUploadController)
+
 import SearchClearController from "./search_clear_controller"
 application.register("search-clear", SearchClearController)
 

--- a/app/views/seichi_memos/_anime.html.erb
+++ b/app/views/seichi_memos/_anime.html.erb
@@ -40,9 +40,10 @@
   </div>
 
   <!-- 🔹 作品イメージ -->
-  <div class="mt-4">
+  <div class="mt-4" data-controller="image-upload" data-image-upload-type-value="image_url">
     <label class="block text-gray-700 font-semibold mb-1">作品イメージ</label>
-    <%= f.file_field :image_url, class: "btn w-full p-2 border cursor-pointer shadow-sm" %>
+    <%= f.file_field :image_url, class: "btn w-full p-2 border cursor-pointer shadow-sm", data: { action: "change->image-upload#upload", image_upload_target: "input" } %>
+    <%= f.hidden_field :image_url_cache, data: { image_upload_target: "cacheField" } %>
   </div>
 
   <!-- 🔹 作品ジャンル -->

--- a/app/views/seichi_memos/_form.html.erb
+++ b/app/views/seichi_memos/_form.html.erb
@@ -6,7 +6,7 @@
                         :patch : :post,
               local: true,
               class: "space-y-4",
-              data: { controller: "step-form anime-search seichi-search genre-modal", step_form_target: "form" } do |f| %>
+              data: { controller: "step-form anime-search seichi-search genre-modal image-upload", step_form_target: "form" } do |f| %>
 
   <!-- エラーメッセージを表示 -->
   <div id="form-errors" class="hidden"></div>

--- a/app/views/seichi_memos/_memo.html.erb
+++ b/app/views/seichi_memos/_memo.html.erb
@@ -35,14 +35,16 @@
   </div>
 
   <!-- 🔹 画像アップロード -->
-  <div class="mt-4">
+  <div class="mt-4" data-controller="image-upload" data-image-upload-type-value="seichi_photo">
     <label class="block text-gray-700 font-semibold mb-1">聖地の写真</label>
-    <%= f.file_field :seichi_photo, class: "btn w-full p-2 border cursor-pointer shadow-sm" %>
+    <%= f.file_field :seichi_photo, class: "btn w-full p-2 border cursor-pointer shadow-sm", data: { action: "change->image-upload#upload", image_upload_target: "input" } %>
+    <%= f.hidden_field :seichi_photo_cache, data: { image_upload_target: "cacheField" } %>
   </div>
 
-  <div class="mt-4">
+  <div class="mt-4" data-controller="image-upload" data-image-upload-type-value="scene_image">
     <label class="block text-gray-700 font-semibold mb-1">聖地が登場したシーン画像</label>
-    <%= f.file_field :scene_image, class: "btn w-full p-2 border cursor-pointer shadow-sm" %>
+    <%= f.file_field :scene_image, class: "btn w-full p-2 border cursor-pointer shadow-sm", data: { action: "change->image-upload#upload", image_upload_target: "input" } %>
+    <%= f.hidden_field :scene_image_cache, data: { image_upload_target: "cacheField" } %>
   </div>
 
   <!-- 🔹 ステップボタン -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
       get :confirm # 確認画面でセッション情報を反映する
       get :bookmarks # ブックマークした聖地メモを表示する
       get :autocomplete # オートコンプリート機能
+      post :upload_image # 画像アップロード時に即座にキャッシュ処理を行う
     end
   end
 


### PR DESCRIPTION
## 概要
フォームの送信時に画像を送るのではなく、画像を選択した瞬間に非同期（Ajax）でサーバーに送信して、キャッシュ名だけを取得してステップフォームに保持する仕組みに変更する
## 実施内容
![image](https://github.com/user-attachments/assets/269203cd-ffcb-445b-ac0b-7d9362ca3b19)

## 関連issue
#153 画像選択時にajaxで画像だけをサーバーに送ってキャッシュ名を受け取る処理