### PR TITLE
Fix/#155 作品イメージ画像の反映遅延に対する対応

### DIFF
--- a/app/controllers/seichi_memos_controller.rb
+++ b/app/controllers/seichi_memos_controller.rb
@@ -24,7 +24,7 @@ class SeichiMemosController < ApplicationController
   def update_session
     session[:seichi_memo] ||= {}
     previous_data = session[:seichi_memo] || {}
-    
+
     if session[:seichi_memo]["id"].blank? && params[:id].present?
       session[:seichi_memo]["id"] = params[:id]
     end

--- a/app/controllers/seichi_memos_controller.rb
+++ b/app/controllers/seichi_memos_controller.rb
@@ -22,11 +22,15 @@ class SeichiMemosController < ApplicationController
 
   # 🔹 各ステップごとにセッションを更新
   def update_session
+    session[:seichi_memo] ||= {}
     previous_data = session[:seichi_memo] || {}
+    
+    if session[:seichi_memo]["id"].blank? && params[:id].present?
+      session[:seichi_memo]["id"] = params[:id]
+    end
 
-    cleaned_previous_data = previous_data.except("id")
+    merged_params = previous_data.except("id").merge(seichi_memo_params.to_h).merge(current_step: params[:step])
 
-    merged_params = cleaned_previous_data.merge(seichi_memo_params.to_h).merge(current_step: params[:step])
     @seichi_memo_form = SeichiMemoForm.new(merged_params)
 
     if previous_data["id"].present?

--- a/app/forms/seichi_memo_form.rb
+++ b/app/forms/seichi_memo_form.rb
@@ -76,8 +76,11 @@ class SeichiMemoForm
 
   # 🔹 現在のフォーム入力内容をセッションに保存するメソッド
   def save_to_session(session)
+    
     session[:seichi_memo] ||= {}
     session[:seichi_memo].merge!(attributes.except("seichi_photo", "scene_image", "image_url"))
+
+    session[:seichi_memo]["id"] = seichi_memo&.id
 
     # キャッシュ名があればセッションに直接保存
     session[:seichi_memo]["seichi_photo_cache"] = seichi_photo_cache if seichi_photo_cache.present?

--- a/app/forms/seichi_memo_form.rb
+++ b/app/forms/seichi_memo_form.rb
@@ -76,7 +76,6 @@ class SeichiMemoForm
 
   # 🔹 現在のフォーム入力内容をセッションに保存するメソッド
   def save_to_session(session)
-    
     session[:seichi_memo] ||= {}
     session[:seichi_memo].merge!(attributes.except("seichi_photo", "scene_image", "image_url"))
 

--- a/app/javascript/controllers/image_upload_controller.js
+++ b/app/javascript/controllers/image_upload_controller.js
@@ -7,6 +7,7 @@ export default class extends Controller {
 
   connect() {
     console.log("📸 image-uploadが接続された")
+    this.checkImageVisibility() // ← ここで呼び出す
   }
 
   upload() {
@@ -34,5 +35,27 @@ export default class extends Controller {
       .catch(error => {
         console.error("画像アップロードに失敗しました:", error)
       })
+  }
+
+  checkImageVisibility() {
+    const image = document.getElementById("preview-image")
+    const container = document.getElementById("image-check-container")
+
+    if (!image || !container) {
+      console.warn("画像またはチェック用コンテナが見つかりませんでした")
+      return
+    }
+
+    // 読み込み後のチェック
+    image.addEventListener("load", () => {
+      if (image.naturalWidth === 0) {
+        container.classList.remove("hidden")
+      }
+    })
+
+    // 読み込み済みなら即時チェック
+    if (image.complete && image.naturalWidth === 0) {
+      container.classList.remove("hidden")
+    }
   }
 }

--- a/app/uploaders/anime_image_uploader.rb
+++ b/app/uploaders/anime_image_uploader.rb
@@ -40,18 +40,4 @@ class AnimeImageUploader < CarrierWave::Uploader::Base
   def extension_allowlist
     %w[jpg jpeg gif png webp]
   end
-
-  # WebPに変換
-  process :convert_to_webp
-
-  def convert_to_webp
-    manipulate! do |img|
-      img.format "webp"
-      img
-    end
-  end
-  # 拡張子を.webpで保存
-  def filename
-    super.chomp(File.extname(super)) + ".webp" if original_filename.present?
-  end
 end

--- a/app/uploaders/scene_image_uploader.rb
+++ b/app/uploaders/scene_image_uploader.rb
@@ -44,18 +44,4 @@ class SceneImageUploader < CarrierWave::Uploader::Base
   def extension_allowlist
     %w[jpg jpeg gif png webp]
   end
-
-  # WebPに変換
-  process :convert_to_webp
-
-  def convert_to_webp
-    manipulate! do |img|
-      img.format "webp"
-      img
-    end
-  end
-  # 拡張子を.webpで保存
-  def filename
-    super.chomp(File.extname(super)) + ".webp" if original_filename.present?
-  end
 end

--- a/app/uploaders/seichi_photo_uploader.rb
+++ b/app/uploaders/seichi_photo_uploader.rb
@@ -42,18 +42,4 @@ class SeichiPhotoUploader < CarrierWave::Uploader::Base
   def extension_allowlist
     %w[jpg jpeg gif png webp]
   end
-
-  # WebPに変換
-  process :convert_to_webp
-
-  def convert_to_webp
-    manipulate! do |img|
-      img.format "webp"
-      img
-    end
-  end
-  # 拡張子を.webpで保存
-  def filename
-    super.chomp(File.extname(super)) + ".webp" if original_filename.present?
-  end
 end

--- a/app/views/seichi_memos/_form.html.erb
+++ b/app/views/seichi_memos/_form.html.erb
@@ -8,6 +8,9 @@
               class: "space-y-4",
               data: { controller: "step-form anime-search seichi-search genre-modal image-upload", step_form_target: "form" } do |f| %>
 
+  <%# 編集モード時に投稿IDを保持するためのhiddenフィールド。Stimulus経由で送信されるFormDataに含めるため必要 %>
+  <%= hidden_field_tag :id, @seichi_memo_form.seichi_memo.id if @seichi_memo_form.persisted? %>
+
   <!-- エラーメッセージを表示 -->
   <div id="form-errors" class="hidden"></div>
   <%= render "shared/error_messages", resource: @seichi_memo_form %>

--- a/app/views/seichi_memos/confirm.html.erb
+++ b/app/views/seichi_memos/confirm.html.erb
@@ -94,6 +94,18 @@
       </div>
     </div>
 
+    <!-- 🔹 画像が表示されない場合の再読み込み案内 -->
+    <div id="image-check-container" class="mt-6 hidden">
+      <p class="text-sm text-red-600 mb-2">画像が表示されていない場合は、再読み込みしてください。</p>
+      <button
+        type="button"
+        class="btn bg-primary text-white"
+        onclick="window.location.reload();"
+      >
+        確認画面を再読み込みする
+      </button>
+    </div>
+
     <!-- 🔹 ステップボタン -->
     <div class="flex justify-center mt-4 space-x-4">
       <%= link_to "戻る", "javascript:history.back()", class: "btn bg-gray-300 text-black py-2 px-6 shadow-md" %>


### PR DESCRIPTION
## 概要
Stimulusのupload()処理が完了する前に「次へ（step遷移）」してしまうことで、画像が確認画面（confirmアクション）に正しく反映されない。
## 実施内容
- 投稿編集時に新たな画像を追加した際に確認画面で更新できない不具合を修正
- 確認画面で画像が表示されない場合の再読み込み機能を追加
- webp変換の削除
## 関連issue
#155 作品イメージ画像の反映遅延に対する対応