### PR TITLE
Feature/#165 マップ検索機能

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -8,12 +8,14 @@
     font-weight: 400;
     font-style: normal;
   }
-}
 
-@layer utilities {
   .font-kosugi {
-  font-family: "Kosugi", sans-serif;
-  font-weight: 400;
-  font-style: normal;
+    font-family: "Kosugi", sans-serif;
+    font-weight: 400;
+    font-style: normal;
+  }
+
+  .h-map {
+    height: calc(100vh - 64px - 64px); /* ヘッダーとフッター分を引く */
   }
 }

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,0 +1,5 @@
+class MapsController < ApplicationController
+  def index
+    @seichi_memos = SeichiMemo.includes(:anime, :place, :user, :genre_tags).where.not(places: { address: '', latitude: nil, longitude: nil })
+  end
+end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,5 +1,5 @@
 class MapsController < ApplicationController
   def index
-    @seichi_memos = SeichiMemo.includes(:anime, :place, :user, :genre_tags).where.not(places: { address: '', latitude: nil, longitude: nil })
+    @seichi_memos = SeichiMemo.includes(:anime, :place, :user, :genre_tags).where.not(places: { address: "", latitude: nil, longitude: nil })
   end
 end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -30,7 +30,7 @@
     <% features = [
       { title: "聖地メモ作成投稿", image: "camera_and_memory_icon.webp", desc: "聖地巡礼で訪れた聖地の思い出を投稿しよう！！" },
       { title: "みんなの聖地メモの閲覧", image: "map_with_pin_icon.webp", desc: "みんなの聖地メモを見て次に訪れたい聖地を見つけよう！！" },
-      { title: "聖地メモ検索", image: "search_icon.webp", desc: "聖地名、作品タイトル、作品ジャンル、エリア、マップ検索（実装予定）からの検索ができます" }
+      { title: "聖地メモ検索", image: "search_icon.webp", desc: "聖地名、作品タイトル、作品ジャンル、エリア、マップ検索からの検索ができます" }
     ] %>
 
     <% features.each_with_index do |feature, i| %>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,89 +1,151 @@
 <% content_for(:title, t('.title')) %>
 
-<%# 🔹 検索フォーム & 現在地ボタン（上部中央） %>
-<div id="search-container" class="fixed top-4 left-1/2 transform -translate-x-1/2 z-10 flex justify-center space-x-2 w-11/12 sm:w-2/3">
-  <input id="pac-input" class="controls input input-bordered input-sm w-full" type="text" placeholder="聖地名">
-  <button id="current-location-btn" class="btn btn-sm btn-primary text-white">現在地</button>
+<%# 🔹 検索フォーム＋現在地ボタンの表示（レスポンシブ対応、固定位置） %>
+<div id="search-container" class="fixed top-28 sm:top-4 left-1/2 transform -translate-x-1/2 z-10 flex justify-center space-x-2 w-4/5 sm:w-3/5 scale-90 sm:scale-100">
+  <input id="pac-input" class="controls input input-bordered input-sm flex-grow text-[16px] bg-white" type="text" placeholder="店名/地名">
+  <button id="current-location-btn" class="btn btn-sm btn-primary text-xs sm:text-sm text-white">現在地</button>
 </div>
 
-<%# 🔹 レイアウト：マップ + 聖地メモ一覧を横並び or 縦並び（レスポンシブ） %>
-<div class="flex flex-col md:flex-row h-[90vh] mt-20 px-4 gap-4">
-  <%# 🔹 地図表示領域 %>
-  <div id="map" class="w-full md:w-2/3 h-96 md:h-full rounded shadow"></div>
-
-  <%# 🔹 聖地メモ一覧（スクロール可） %>
-  <div class="w-full md:w-1/3 overflow-y-auto h-96 md:h-full bg-white rounded shadow p-4">
-    <h2 class="text-lg font-bold mb-2">聖地メモ一覧</h2>
-    <% @seichi_memos.each do |memo| %>
-      <div class="border-b py-2">
-        <p class="text-sm text-gray-600"><%= memo.anime.title %>（<%= memo.place.name %>）</p>
-        <p class="font-semibold"><%= memo.title %></p>
-        <p class="text-xs text-gray-500"><%= memo.place.address %></p>
-        <%= link_to '詳細を見る', seichi_memo_path(memo), class: "text-blue-600 hover:underline text-sm" %>
-      </div>
-    <% end %>
+<%# 🔹 Google Mapを描画するエリア（ローディング中はアニメーション表示） %>
+<div id="map-container" class="flex-grow w-full">
+  <div id="map" class="relative w-full h-full">
+    <div class="absolute inset-0 flex items-center justify-center">
+      <img src="<%= asset_path('apple-touch-icon.png') %>" class="w-6 h-6 animate-bounce-slow" alt="Loading">
+    </div>
   </div>
 </div>
 
-<%# 🔹 Google Maps の表示用スクリプト %>
+<%# 🔹 モーダル（クリックされたマーカーの詳細を表示） %>
+<dialog id="post_modal" class="modal">
+  <div class="modal-box bg-white">
+    <div class="post_show"></div>
+  </div>
+</dialog>
+
 <script>
-  let map;
+// 🔹 地図と現在地マーカーを扱う変数を宣言
+let map, marker;
 
-  function initMap() {
-    const center = { lat: 35.6803997, lng: 139.7690174 }; // 東京駅
+// 🔹 情報表示用DOMの取得（使用しない場合は削除OK）
+const latlngDis = document.getElementById('latlngDisplay');
+const addressDis = document.getElementById('addressDisplay');
 
-    map = new google.maps.Map(document.getElementById("map"), {
-      center: center,
-      zoom: 10,
-      gestureHandling: 'greedy',
+// 🔹 カスタムマーカーアイコン
+const iconImage = 'https://maps.google.com/mapfiles/ms/micons/yellow-dot.png';
+const currentLocation = 'https://www.google.com/mapfiles/marker.png';
+
+// 🔹 Google Maps APIが呼び出すコールバック関数（グローバルスコープに登録）
+window.initMap = function() {
+  // 🔹 地図の初期設定
+  map = new google.maps.Map(document.getElementById('map'), {
+    zoom: 12,
+    gestureHandling: 'greedy',
+    center: { lat: 35.6803997, lng: 139.7690174 } // 東京駅を初期中心に
+  });
+
+  // 🔹 検索ボックスの設定
+  const input = document.getElementById("pac-input");
+  const searchBox = new google.maps.places.SearchBox(input);
+
+  // 🔹 現在地ボタンのイベント登録
+  document.getElementById('current-location-btn').addEventListener('click', showCurrentLocation);
+
+  // 🔹 地図が移動した時に検索範囲を更新
+  map.addListener("bounds_changed", () => {
+    searchBox.setBounds(map.getBounds());
+  });
+
+  // 🔹 検索で表示されるマーカーを一時的に保存
+  let markers = [];
+
+  // 🔹 検索候補から場所が選ばれたときの処理
+  searchBox.addEventListener("places_changed", () => {
+    const places = searchBox.getPlaces();
+    if (places.length === 0) return;
+
+    // 🔹 既存マーカーを削除
+    markers.forEach((marker) => marker.setMap(null));
+    markers = [];
+
+    // 🔹 新しい候補に合わせて地図の範囲を更新
+    const bounds = new google.maps.LatLngBounds();
+    places.forEach((place) => {
+      if (!place.geometry || !place.geometry.location) return;
+      place.geometry.viewport ? bounds.union(place.geometry.viewport) : bounds.extend(place.geometry.location);
     });
+    map.fitBounds(bounds);
+  });
 
-    const input = document.getElementById("pac-input");
-    const searchBox = new google.maps.places.SearchBox(input);
+  // 🔹 初期状態で現在地を表示
+  showCurrentLocation();
 
-    // 🔹 検索範囲制限
-    map.addListener("bounds_changed", () => {
-      searchBox.setBounds(map.getBounds());
-    });
+  // 🔹 聖地メモに対応するマーカーピンを立てる
+  setMemoMarkers();
 
-    // 🔹 現在地ボタン
-    document.getElementById("current-location-btn").addEventListener("click", () => {
-      if (navigator.geolocation) {
-        navigator.geolocation.getCurrentPosition((position) => {
-          const pos = {
-            lat: position.coords.latitude,
-            lng: position.coords.longitude
-          };
-          map.setCenter(pos);
-          new google.maps.Marker({
-            position: pos,
-            map: map,
-            icon: 'https://www.google.com/mapfiles/marker.png'
-          });
-        }, () => {
-          alert("位置情報の取得に失敗しました。");
-        });
-      } else {
-        alert("お使いのブラウザでは位置情報が利用できません。");
-      }
-    });
+  // 🔹 モーダル外をクリックしたときに閉じる
+  document.addEventListener('click', function(event) {
+    const modal = document.getElementById('post_modal');
+    if (event.target === modal) {
+      modal.close();
+    }
+  });
+};
 
-    // 🔹 聖地メモのマーカーを表示
-    <% @seichi_memos.each do |memo| %>
-      new google.maps.Marker({
-        position: {
-          lat: <%= memo.place.latitude %>,
-          lng: <%= memo.place.longitude %>
-        },
+// 🔹 現在地を取得して地図を移動、ピンを表示
+function showCurrentLocation(){
+  if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(function(position) {
+      const userLocation = {
+        lat: position.coords.latitude,
+        lng: position.coords.longitude
+      };
+      map.setCenter(userLocation);
+
+      if (marker) marker.setMap(null);
+
+      marker = new google.maps.Marker({
+        position: userLocation,
         map: map,
-        title: "<%= j memo.title %>"
+        icon: currentLocation
       });
-    <% end %>
-  }
 
-  // 🔹 グローバル登録
-  window.initMap = initMap;
+      if (latlngDis) latlngDis.innerHTML = `Latitude: ${userLocation.lat}, Longitude: ${userLocation.lng}`;
+    }, function() {
+      alert('位置情報の取得に失敗しました。');
+    });
+  } else {
+    alert('お使いのブラウザでは地理位置情報の取得がサポートされていません。');
+  }
+}
+
+// 🔹 各聖地メモに対応するマーカーを地図に配置し、モーダルで詳細表示
+function setMemoMarkers() {
+  <% @seichi_memos.each do |memo| %>
+    (() => {
+      const marker = new google.maps.Marker({
+        position: { lat: <%= memo.place.latitude %>, lng: <%= memo.place.longitude %> },
+        map: map,
+        title: "<%= j memo.title %>",
+        icon: iconImage
+      });
+
+      marker.addListener('click', function() {
+        const modalContent = `
+          <div class='text-center'>
+            <div class='text-xs'><%= j t("enums.post.category.#{memo.category}") %></div>
+            <div class='text-lg font-semibold'><%= j memo.place.name %></div>
+            <p class='text-sm text-gray-600'><%= j memo.place.address %></p>
+            <p class='text-sm mt-2'><%= j memo.body.truncate(60) %></p>
+            <a href="<%= seichi_memo_path(memo) %>" class="text-blue-500 hover:underline mt-2 inline-block">詳細を見る</a>
+          </div>
+        `;
+        document.querySelector('.post_show').innerHTML = modalContent;
+        document.getElementById('post_modal').showModal();
+      });
+    })();
+  <% end %>
+}
 </script>
 
-<%# 🔹 Google Maps API 読み込み（APIキーは .env で管理） %>
-<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&libraries=places&callback=initMap" async defer></script>
+<%# 🔹Google Maps APIを読み込むスクリプトタグ（ENVからAPIキーを取得） %>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_PLACES_API_KEY'] %>&libraries=places&callback=initMap" async defer></script>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,0 +1,89 @@
+<% content_for(:title, t('.title')) %>
+
+<%# 🔹 検索フォーム & 現在地ボタン（上部中央） %>
+<div id="search-container" class="fixed top-4 left-1/2 transform -translate-x-1/2 z-10 flex justify-center space-x-2 w-11/12 sm:w-2/3">
+  <input id="pac-input" class="controls input input-bordered input-sm w-full" type="text" placeholder="聖地名">
+  <button id="current-location-btn" class="btn btn-sm btn-primary text-white">現在地</button>
+</div>
+
+<%# 🔹 レイアウト：マップ + 聖地メモ一覧を横並び or 縦並び（レスポンシブ） %>
+<div class="flex flex-col md:flex-row h-[90vh] mt-20 px-4 gap-4">
+  <%# 🔹 地図表示領域 %>
+  <div id="map" class="w-full md:w-2/3 h-96 md:h-full rounded shadow"></div>
+
+  <%# 🔹 聖地メモ一覧（スクロール可） %>
+  <div class="w-full md:w-1/3 overflow-y-auto h-96 md:h-full bg-white rounded shadow p-4">
+    <h2 class="text-lg font-bold mb-2">聖地メモ一覧</h2>
+    <% @seichi_memos.each do |memo| %>
+      <div class="border-b py-2">
+        <p class="text-sm text-gray-600"><%= memo.anime.title %>（<%= memo.place.name %>）</p>
+        <p class="font-semibold"><%= memo.title %></p>
+        <p class="text-xs text-gray-500"><%= memo.place.address %></p>
+        <%= link_to '詳細を見る', seichi_memo_path(memo), class: "text-blue-600 hover:underline text-sm" %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<%# 🔹 Google Maps の表示用スクリプト %>
+<script>
+  let map;
+
+  function initMap() {
+    const center = { lat: 35.6803997, lng: 139.7690174 }; // 東京駅
+
+    map = new google.maps.Map(document.getElementById("map"), {
+      center: center,
+      zoom: 10,
+      gestureHandling: 'greedy',
+    });
+
+    const input = document.getElementById("pac-input");
+    const searchBox = new google.maps.places.SearchBox(input);
+
+    // 🔹 検索範囲制限
+    map.addListener("bounds_changed", () => {
+      searchBox.setBounds(map.getBounds());
+    });
+
+    // 🔹 現在地ボタン
+    document.getElementById("current-location-btn").addEventListener("click", () => {
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition((position) => {
+          const pos = {
+            lat: position.coords.latitude,
+            lng: position.coords.longitude
+          };
+          map.setCenter(pos);
+          new google.maps.Marker({
+            position: pos,
+            map: map,
+            icon: 'https://www.google.com/mapfiles/marker.png'
+          });
+        }, () => {
+          alert("位置情報の取得に失敗しました。");
+        });
+      } else {
+        alert("お使いのブラウザでは位置情報が利用できません。");
+      }
+    });
+
+    // 🔹 聖地メモのマーカーを表示
+    <% @seichi_memos.each do |memo| %>
+      new google.maps.Marker({
+        position: {
+          lat: <%= memo.place.latitude %>,
+          lng: <%= memo.place.longitude %>
+        },
+        map: map,
+        title: "<%= j memo.title %>"
+      });
+    <% end %>
+  }
+
+  // 🔹 グローバル登録
+  window.initMap = initMap;
+</script>
+
+<%# 🔹 Google Maps API 読み込み（APIキーは .env で管理） %>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&libraries=places&callback=initMap" async defer></script>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,18 +1,14 @@
 <% content_for(:title, t('.title')) %>
 
-<%# 🔹 検索フォーム＋現在地ボタンの表示（レスポンシブ対応、固定位置） %>
-<div id="search-container" class="fixed top-28 sm:top-4 left-1/2 transform -translate-x-1/2 z-10 flex justify-center space-x-2 w-4/5 sm:w-3/5 scale-90 sm:scale-100">
-  <input id="pac-input" class="controls input input-bordered input-sm flex-grow text-[16px] bg-white" type="text" placeholder="店名/地名">
-  <button id="current-location-btn" class="btn btn-sm btn-primary text-xs sm:text-sm text-white">現在地</button>
+<!--🔹 検索フォーム＋現在地ボタンの表示 -->
+<div id="search-container" class="fixed top-28 sm:top-20 left-1/2 transform -translate-x-1/2 z-[50] bg-transparent px-4 py-2 rounded-md flex justify-center space-x-2 shadow-none w-11/12 sm:w-4/5 lg:w-2/5">
+  <input id="pac-input" class="input input-bordered input-sm flex-grow text-[16px] bg-white bg-opacity-100" type="text" placeholder="聖地名">
+  <button id="current-location-btn" class="btn btn-sm btn-primary text-xs sm:text-sm text-white shadow-md transition duration-200">現在地</button>
 </div>
 
 <%# 🔹 Google Mapを描画するエリア（ローディング中はアニメーション表示） %>
-<div id="map-container" class="flex-grow w-full">
-  <div id="map" class="relative w-full h-full">
-    <div class="absolute inset-0 flex items-center justify-center">
-      <img src="<%= asset_path('apple-touch-icon.png') %>" class="w-6 h-6 animate-bounce-slow" alt="Loading">
-    </div>
-  </div>
+<div id="map-container" class="relative overflow-hidden h-map w-full">
+  <div id="map" class="w-full h-full"></div>
 </div>
 
 <%# 🔹 モーダル（クリックされたマーカーの詳細を表示） %>
@@ -59,7 +55,7 @@ window.initMap = function() {
   let markers = [];
 
   // 🔹 検索候補から場所が選ばれたときの処理
-  searchBox.addEventListener("places_changed", () => {
+  searchBox.addListener("places_changed", () => {
     const places = searchBox.getPlaces();
     if (places.length === 0) return;
 
@@ -123,20 +119,58 @@ function setMemoMarkers() {
   <% @seichi_memos.each do |memo| %>
     (() => {
       const marker = new google.maps.Marker({
-        position: { lat: <%= memo.place.latitude %>, lng: <%= memo.place.longitude %> },
+        position: { lat: <%= memo.place.latitude || 0 %>, lng: <%= memo.place.longitude || 0 %> },
         map: map,
-        title: "<%= j memo.title %>",
+        title: <%= raw(json_escape(memo.title.to_json)) %>,
         icon: iconImage
       });
 
       marker.addListener('click', function() {
         const modalContent = `
-          <div class='text-center'>
-            <div class='text-xs'><%= j t("enums.post.category.#{memo.category}") %></div>
-            <div class='text-lg font-semibold'><%= j memo.place.name %></div>
-            <p class='text-sm text-gray-600'><%= j memo.place.address %></p>
-            <p class='text-sm mt-2'><%= j memo.body.truncate(60) %></p>
-            <a href="<%= seichi_memo_path(memo) %>" class="text-blue-500 hover:underline mt-2 inline-block">詳細を見る</a>
+          <div class="bg-white/70 backdrop-blur-md p-2 rounded-lg flex flex-col">
+            <div class="h-60 flex items-center justify-center rounded-md overflow-hidden">
+              <img src="<%= memo.seichi_photo.present? ? memo.seichi_photo.url : SeichiPhotoUploader.new.default_url %>" alt="聖地画像" class="object-cover w-full h-full cursor-default transition">
+            </div>
+            <div class="flex flex-grow flex-col">
+              <div class="flex items-start mt-3 space-x-2 justify-start">
+                <h2 class="text-lg font-bold flex-grow"><%= j memo.title.truncate(25) %></h2>
+              </div>
+              <h3 class="font-bold"><%= j memo.anime.title %></h3>
+              <div class="flex flex-wrap gap-2 mt-2">
+                <% memo.genre_tags.each do |tag| %>
+                  <span class="bg-primary text-gray-700 text-xs font-medium px-2 py-0.5 rounded-full"><%= j tag.name %></span>
+                <% end %>
+              </div>
+              <p class="text-gray-600 line-clamp-3 mt-2"><%= j memo.body.truncate(100) %></p>
+            </div>
+            <div class="flex items-center justify-between mt-4 px-2">
+              <div class="flex items-center space-x-2">
+                <a href="<%= memo.user == current_user ? profile_path : user_path(memo.user) %>" data-action="click->loading#show">
+                  <img src="<%= memo.user.profile_image.url %>" alt="<%= j memo.user.username %>" class="w-8 h-8 rounded-full">
+                </a>
+                <div class="flex flex-col">
+                  <span class="text-gray-700 text-sm font-medium"><%= j memo.user.username %></span>
+                  <span class="text-xs text-gray-500"><%= memo.created_at.strftime("%Y年%m月%d日") %></span>
+                </div>
+              </div>
+              <div class="flex items-center gap-4">
+                <%= j render 'likes/like_buttons', seichi_memo: memo %>
+                <%= j render 'bookmarks/bookmark_buttons', seichi_memo: memo %>
+              </div>
+            </div>
+
+            <div class="mt-4 flex justify-center gap-4">
+              <a href="/seichi_memos/<%= memo.id %>" class="btn bg-primary text-white py-2 px-6 shadow-md transition duration-200">
+                <i class="fa-solid fa-circle-info mr-1"></i>
+                <span>詳細ページへ</span>
+              </a>
+              <a href="https://www.google.com/maps/search/?api=1&query=<%= CGI.escape(memo.place.name.to_s + ' ' + memo.place.address.to_s) %>" 
+                target="_blank"
+                class="btn bg-primary text-white py-2 px-6 shadow-md transition duration-200">
+                <i class="fa-solid fa-map-location-dot mr-1"></i>
+                <span>ここへ行く</span>
+              </a>
+            </div>
           </div>
         `;
         document.querySelector('.post_show').innerHTML = modalContent;

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -159,14 +159,14 @@ function setMemoMarkers() {
               </div>
             </div>
 
-            <div class="mt-4 flex justify-center gap-4">
-              <a href="/seichi_memos/<%= memo.id %>" class="btn bg-primary text-white py-2 px-6 shadow-md transition duration-200">
+            <div class="mt-4 flex flex-col sm:flex-row justify-center gap-4">
+              <a href="/seichi_memos/<%= memo.id %>" class="btn bg-primary text-white py-2 px-6 shadow-md transition duration-200 text-center w-full sm:w-auto">
                 <i class="fa-solid fa-circle-info mr-1"></i>
                 <span>詳細ページへ</span>
               </a>
               <a href="https://www.google.com/maps/search/?api=1&query=<%= CGI.escape(memo.place.name.to_s + ' ' + memo.place.address.to_s) %>" 
                 target="_blank"
-                class="btn bg-primary text-white py-2 px-6 shadow-md transition duration-200">
+                class="btn bg-primary text-white py-2 px-6 shadow-md transition duration-200 text-center w-full sm:w-auto">
                 <i class="fa-solid fa-map-location-dot mr-1"></i>
                 <span>ここへ行く</span>
               </a>

--- a/app/views/seichi_memos/_anime.html.erb
+++ b/app/views/seichi_memos/_anime.html.erb
@@ -29,7 +29,7 @@
 
     <!-- 🔹 オートコンプリート候補表示エリア -->
     <div data-anime-search-target="suggestions"
-      class="absolute z-50 mt-1 w-full bg-white rounded-md shadow-lg">
+      class="absolute z-50 mt-1 w-full bg-white rounded-md shadow-lg list-none">
     </div>
   </div>
 

--- a/app/views/seichi_memos/_place.html.erb
+++ b/app/views/seichi_memos/_place.html.erb
@@ -29,7 +29,7 @@
 
     <!-- 🔹 オートコンプリート候補表示エリア -->
     <div data-seichi-search-target="suggestions"
-        class="absolute z-10 w-full bg-white mt-1 rounded-md shadow-lg max-h-60 overflow-y-auto">
+        class="absolute z-10 w-full bg-white mt-1 rounded-md shadow-lg max-h-60 overflow-y-auto list-none">
     </div>
   </div>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<div class="drawer drawer-end z-[50]">
+<div class="drawer drawer-end z-[60]">
   <!-- チェックボックスによる開閉制御 -->
   <input id="menu-drawer" type="checkbox" class="drawer-toggle" />
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -43,7 +43,7 @@
         <li><%= link_to destroy_user_session_path, data: { turbo_method: :delete, action: "click->loading#show" } do %><i class="fa-solid fa-right-from-bracket"></i> ログアウト <% end %></li>
         <div class="divider"></div>
         <li><%= link_to seichi_memos_path, data: { action: "click->loading#show" } do %><i class="fas fa-search"></i> 聖地メモ検索 <% end %></li>
-        <li><%= link_to "#" do %><i class="fa-solid fa-map-location-dot"></i> マップ検索（実装予定）<% end %></li>
+        <li><%= link_to maps_path, data: { action: "click->loading#show" } do %><i class="fa-solid fa-map-location-dot"></i> マップ検索<% end %></li>
         <li><%= link_to new_seichi_memo_path, data: { action: "click->loading#show" } do %><i class="fas fa-plus-circle"></i> 聖地メモ作成 <% end %></li>
         <li><%= link_to bookmarks_seichi_memos_path, data: { action: "click->loading#show" } do %><i class="fa-solid fa-bookmark"></i> ブックマーク <% end %></li>
         <li><%= link_to columns_path, data: { action: "click->loading#show" } do %><i class="fa-solid fa-hands-praying"></i> 聖地巡礼コラム <% end %></li>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -40,3 +40,6 @@ ja:
   columns:
     index:
       title: 聖地巡礼コラム
+  maps:
+    index:
+      title: マップ検索

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,8 +36,9 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :bookmarks, only: %i[create destroy]
-  resources :columns, only: %i[index]
+  resources :bookmarks, only: %i[create destroy] # ブックマークのルーティング
+  resources :columns, only: %i[index] # コラム一覧のルーティング
+  resources :maps, only: %i[index] # 地図表示用のルーティング
 
   # Health check ルート（アップタイムモニタリング用）
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
## 概要
ハンバーガーメニューの「マップ検索」をクリックするとGoogleマップが表示されること
投稿する際に緯度と経度を保存する（実装済み）
すべての聖地メモの投稿内容を一つの地図上で一覧表示させる
マーカーをクリックすると投稿の内容が出てそこから「詳細へ」ボタンを押すとその投稿の詳細画面に遷移する
地名のキーワード検索を用意して地図上の検索ができること（プレスホルダーに「聖地名」とつける
まずマップ検索画面に遷移すると現在値の取得を行いそこを初期値として表示されるようにする
「現在値」というボタンを押すと現在地のピンが指してあるところが表示されること
キーワード検索のフォームと現在値のボタンはタブレット以上ではヘッダーで表示してスマホ画面では地図上に表示すること
## 実施内容
![image](https://github.com/user-attachments/assets/bbb0281b-20ac-4abc-879d-b915ca4fadf7)

## 関連issue
#165 マップ検索機能