### PR TITLE
Fix/マップ検索周りの修正

### DIFF
--- a/app/views/columns/index.html.erb
+++ b/app/views/columns/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t(".title")) %>
 
-<div class="container mx-auto mt-8 px-4 sm:px-6 lg:px-8">
+<div class="container mx-auto mt-8 px-4 sm:px-6 lg:px-8 mb-24">
   <h1 class="text-xl sm:text-2xl md:text-3xl font-bold text-center text-transparent bg-clip-text bg-gradient-to-r from-primary to-pink-500 tracking-wide mb-6 sm:mb-8">
     あなたの足で紡ぐ、作品と現実の交差点
   </h1>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t(".title")) %>
 
-<section class="px-4 py-12 sm:px-6 lg:px-8">
+<div class="px-4 py-12 sm:px-6 lg:px-8 mb-24">
   <h2 class="text-3xl sm:text-4xl font-bold text-center text-gray-800 mb-8">プロフィール編集</h2>
 
   <div class="max-w-screen-md w-full mx-auto bg-white shadow-lg rounded-2xl px-4 sm:px-8 py-8 sm:py-10">
@@ -50,4 +50,4 @@
       </div>
     <% end %>
   </div>
-</section>
+</div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -116,7 +116,7 @@
 </div>
 
 <!-- 聖地メモ投稿ボタンセクション -->
-<div class="mt-4 text-center" data-aos="fade-up" data-aos-delay="100">
+<div class="mt-4 mb-24 text-center" data-aos="fade-up" data-aos-delay="100">
   <%= link_to "聖地メモを投稿する", new_seichi_memo_path,
     class: "btn bg-primary text-white rounded-full shadow-md transition duration-200",
     data: { action: "click->loading#show" } %>

--- a/app/views/homes/privacy_policy.html.erb
+++ b/app/views/homes/privacy_policy.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t(".title")) %>
 
-<section class="bg-base-100 py-12 px-4 sm:px-6 lg:px-8">
+<div class="bg-base-100 py-6 px-4 sm:px-6 lg:px-8 mb-24">
   <div class="bg-white max-w-6xl mx-auto shadow-xl rounded-2xl overflow-hidden">
     <div class="bg-white p-6 sm:p-10">
       <!-- ヘッダー -->
@@ -83,4 +83,4 @@
       </div>
     </div>
   </div>
-</section>
+</div>

--- a/app/views/homes/terms_of_service.html.erb
+++ b/app/views/homes/terms_of_service.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t(".title")) %>
 
-<section class="bg-base-100 py-12 px-4 sm:px-6 lg:px-8">
+<div class="bg-base-100 py-6 px-4 sm:px-6 lg:px-8 mb-24" >
   <div class="bg-white max-w-6xl mx-auto shadow-xl rounded-2xl overflow-hidden">
     <div class="bg-white p-6 sm:p-10">
       <!-- タイトル -->
@@ -242,4 +242,4 @@
       </div>
     </div>
   </div>
-</section>
+</div>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -7,5 +7,12 @@
     remote:        data-remote
 -%>
 <span class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, class: "join-item btn bg-primary text-white font-bold py-2 px-6 rounded-lg shadow-md transition duration-200 max-w-xs", rel: 'next', remote: remote, data: { action: "click->loading#show" } %>
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url,
+    class: "join-item btn btn-sm bg-primary text-white font-semibold px-4 py-2 rounded-full hover:bg-primary/80 hover:shadow-lg transition-all duration-300 ease-in-out inline-flex items-center space-x-2",
+    rel: 'next',
+    remote: remote,
+    data: { action: "click->loading#show" } do %>
+      <span><%= t('views.pagination.next') %></span>
+      <i class="fa-solid fa-arrow-right"></i>
+  <% end %>
 </span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -7,4 +7,8 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<%= link_to page, url, class: "join-item btn #{'btn-active' if page.current?} btn bg-primary text-white font-bold py-2 px-6 rounded-lg shadow-md transition duration-200 max-w-xs", remote: true, rel: page.rel, data: { action: "click->loading#show" } %>
+<%= link_to page, url,
+  class: "join-item btn btn-sm #{'bg-primary text-white' if page.current?} #{'bg-white text-primary border border-primary' unless page.current?} font-semibold px-3 py-2 rounded-full shadow-md hover:shadow-lg transition-all duration-300 ease-in-out",
+  remote: true,
+  rel: page.rel,
+  data: { action: "click->loading#show" } %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -7,5 +7,12 @@
     remote:        data-remote
 -%>
 <span class="prev">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, class: "join-item btn bg-primary text-white font-bold py-2 px-6 rounded-lg shadow-md transition duration-200 max-w-xs", rel: 'prev', remote: remote, data: { action: "click->loading#show" } %>
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url,
+    class: "join-item btn btn-sm bg-primary text-white font-semibold px-4 py-2 rounded-full hover:bg-primary/80 hover:shadow-lg transition-all duration-300 ease-in-out inline-flex items-center space-x-2",
+    rel: 'prev',
+    remote: remote,
+    data: { action: "click->loading#show" } do %>
+      <i class="fa-solid fa-arrow-left"></i>
+      <span><%= t('views.pagination.previous') %></span>
+  <% end %>
 </span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,7 @@
 
       <%= render 'layouts/flash_messages' %>
       <%= render 'shared/header' %>
-      <main class="flex-grow w-full max-w-none pb-24">
+      <main class="flex-grow w-full max-w-none">
         <%= yield %>
       </main>
       <% if user_signed_in? %>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -128,9 +128,12 @@ function setMemoMarkers() {
       marker.addListener('click', function() {
         const modalContent = `
           <div class="bg-white/70 backdrop-blur-md p-2 rounded-lg flex flex-col">
+            <!-- 聖地の写真 -->
             <div class="h-60 flex items-center justify-center rounded-md overflow-hidden">
-              <img src="<%= memo.seichi_photo.present? ? memo.seichi_photo.url : SeichiPhotoUploader.new.default_url %>" alt="聖地画像" class="object-cover w-full h-full cursor-default transition">
+              <%= image_tag (memo.seichi_photo.present? ? memo.seichi_photo.url : SeichiPhotoUploader.new.default_url), alt:"聖地の写真", class:"object-cover w-full h-full cursor-default transition" %>
             </div>
+
+            <!-- コンテンツ -->
             <div class="flex flex-grow flex-col">
               <div class="flex items-start mt-3 space-x-2 justify-start">
                 <h2 class="text-lg font-bold flex-grow"><%= j memo.title.truncate(25) %></h2>
@@ -143,33 +146,40 @@ function setMemoMarkers() {
               </div>
               <p class="text-gray-600 line-clamp-3 mt-2"><%= j memo.body.truncate(100) %></p>
             </div>
+
+            <!-- ユーザー情報 -->
             <div class="flex items-center justify-between mt-4 px-2">
               <div class="flex items-center space-x-2">
-                <a href="<%= memo.user == current_user ? profile_path : user_path(memo.user) %>" data-action="click->loading#show">
-                  <img src="<%= memo.user.profile_image.url %>" alt="<%= j memo.user.username %>" class="w-8 h-8 rounded-full">
-                </a>
+                <%= link_to (memo.user == current_user ? profile_path : user_path(memo.user)), data: { action: "click->loading#show" } do %>
+                  <%= image_tag memo.user.profile_image.url, alt: j(memo.user.username), class: "w-8 h-8 rounded-full" %>
+                <% end %>
                 <div class="flex flex-col">
                   <span class="text-gray-700 text-sm font-medium"><%= j memo.user.username %></span>
                   <span class="text-xs text-gray-500"><%= memo.created_at.strftime("%Y年%m月%d日") %></span>
                 </div>
               </div>
+
+              <!-- アクションボタン(ブックマーク、いいね) -->
               <div class="flex items-center gap-4">
                 <%= j render 'likes/like_buttons', seichi_memo: memo %>
                 <%= j render 'bookmarks/bookmark_buttons', seichi_memo: memo %>
               </div>
             </div>
 
+            <!-- 詳細ページと地図へ行くボタン -->
             <div class="mt-4 flex flex-col sm:flex-row justify-center gap-4">
-              <a href="/seichi_memos/<%= memo.id %>" class="btn bg-primary text-white py-2 px-6 shadow-md transition duration-200 text-center w-full sm:w-auto">
+              <%= link_to seichi_memo_path(memo),
+                          class: "btn bg-primary text-white py-2 px-6 shadow-md transition duration-200 text-center w-full sm:w-auto",
+                          data: { action: "click->loading#show" } do %>
                 <i class="fa-solid fa-circle-info mr-1"></i>
                 <span>詳細ページへ</span>
-              </a>
-              <a href="https://www.google.com/maps/search/?api=1&query=<%= CGI.escape(memo.place.name.to_s + ' ' + memo.place.address.to_s) %>" 
-                target="_blank"
-                class="btn bg-primary text-white py-2 px-6 shadow-md transition duration-200 text-center w-full sm:w-auto">
+              <% end %>
+              <%= link_to "https://www.google.com/maps/search/?api=1&query=#{CGI.escape(memo.place.name.to_s + ' ' + memo.place.address.to_s)}",
+                          target: "_blank",
+                          class: "btn bg-primary text-white py-2 px-6 shadow-md transition duration-200 text-center w-full sm:w-auto" do %>
                 <i class="fa-solid fa-map-location-dot mr-1"></i>
                 <span>ここへ行く</span>
-              </a>
+              <% end %>
             </div>
           </div>
         `;

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,17 +1,17 @@
 <% content_for(:title, t('.title')) %>
 
 <!--🔹 検索フォーム＋現在地ボタンの表示 -->
-<div id="search-container" class="fixed top-28 sm:top-20 left-1/2 transform -translate-x-1/2 z-[50] bg-transparent px-4 py-2 rounded-md flex justify-center space-x-2 shadow-none w-11/12 sm:w-4/5 lg:w-2/5">
+<div id="search-container" class="fixed top-28 sm:top-20 left-1/2 transform -translate-x-1/2 z-[50] bg-transparent px-4 py-2 rounded-md flex justify-center space-x-2 w-4/5 sm:w-3/5 scale-90 sm:scale-100">
   <input id="pac-input" class="input input-bordered input-sm flex-grow text-[16px] bg-white bg-opacity-100" type="text" placeholder="聖地名">
   <button id="current-location-btn" class="btn btn-sm btn-primary text-xs sm:text-sm text-white shadow-md transition duration-200">現在地</button>
 </div>
 
-<%# 🔹 Google Mapを描画するエリア（ローディング中はアニメーション表示） %>
+<!-- 🔹 Google Mapを描画するエリア -->
 <div id="map-container" class="relative overflow-hidden h-map w-full">
   <div id="map" class="w-full h-full"></div>
 </div>
 
-<%# 🔹 モーダル（クリックされたマーカーの詳細を表示） %>
+<!-- 🔹 モーダル（クリックされたマーカーの詳細を表示） -->
 <dialog id="post_modal" class="modal">
   <div class="modal-box bg-white">
     <div class="post_show"></div>
@@ -191,5 +191,5 @@ function setMemoMarkers() {
 }
 </script>
 
-<%# 🔹Google Maps APIを読み込むスクリプトタグ（ENVからAPIキーを取得） %>
+<!-- 🔹Google Maps APIを読み込むスクリプトタグ（ENVからAPIキーを取得） -->
 <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_PLACES_API_KEY'] %>&libraries=places&callback=initMap" async defer></script>

--- a/app/views/seichi_memos/_form.html.erb
+++ b/app/views/seichi_memos/_form.html.erb
@@ -5,7 +5,7 @@
               method: (@seichi_memo_form.seichi_memo && @seichi_memo_form.seichi_memo.persisted?) ?
                         :patch : :post,
               local: true,
-              class: "space-y-4",
+              class: "space-y-4 mb-24",
               data: { controller: "step-form anime-search seichi-search genre-modal image-upload", step_form_target: "form" } do |f| %>
 
   <%# 編集モード時に投稿IDを保持するためのhiddenフィールド。Stimulus経由で送信されるFormDataに含めるため必要 %>

--- a/app/views/seichi_memos/bookmarks.html.erb
+++ b/app/views/seichi_memos/bookmarks.html.erb
@@ -3,21 +3,23 @@
 <!-- 検索フォーム -->
 <%= render "seichi_memos/search_form", search_url: bookmarks_seichi_memos_path  %>
 
-<div <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-4">
-  <% if @bookmark_seichi_memos.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-      <% @bookmark_seichi_memos.each do |seichi_memo| %>
-        <%= render "seichi_memos/seichi_memo", seichi_memo: seichi_memo %>
-      <% end %>
-    </div>
-  <% else %>
-    <div class="flex justify-center items-center w-full py-10">
-      <p class="text-gray-600 text-xl font-bold text-center">ブックマークした聖地メモはありません。</p>
-    </div>
-  <% end %>
-</div>
+<div class="mb-24">
+  <div <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-4">
+    <% if @bookmark_seichi_memos.any? %>
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+        <% @bookmark_seichi_memos.each do |seichi_memo| %>
+          <%= render "seichi_memos/seichi_memo", seichi_memo: seichi_memo %>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="flex justify-center items-center w-full py-10">
+        <p class="text-gray-600 text-xl font-bold text-center">ブックマークした聖地メモはありません。</p>
+      </div>
+    <% end %>
+  </div>
 
-<!-- ページネーション -->
-<div class="flex justify-center mt-4">
-  <%= paginate @bookmark_seichi_memos %>
+  <!-- ページネーション -->
+  <div class="flex justify-center mt-4">
+    <%= paginate @bookmark_seichi_memos %>
+  </div>
 </div>

--- a/app/views/seichi_memos/confirm.html.erb
+++ b/app/views/seichi_memos/confirm.html.erb
@@ -96,7 +96,7 @@
     </div>
 
     <!-- 🔹 ステップボタン -->
-    <div class="flex justify-center mt-4 space-x-4">
+    <div class="flex justify-center mt-4 mb-24 space-x-4">
       <%= link_to "戻る", "javascript:history.back()", class: "btn bg-gray-300 text-black py-2 px-6 shadow-md", data: { action: "click->loading#show" } %>
       <%= f.submit @seichi_memo_form.persisted? ? "更新する" : "投稿する", class: "btn bg-primary text-white py-2 px-6 shadow-md", data: { action: "click->loading#show" } %>
     </div>

--- a/app/views/seichi_memos/index.html.erb
+++ b/app/views/seichi_memos/index.html.erb
@@ -15,21 +15,23 @@
   <% end %>
 </div>
 
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-4">
-  <% if @seichi_memos.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-      <% @seichi_memos.each do |seichi_memo| %>
-        <%= render "seichi_memos/seichi_memo", seichi_memo: seichi_memo %>
-      <% end %>
-    </div>
-  <% else %>
-    <div class="flex justify-center items-center w-full py-10">
-      <p class="text-gray-600 text-xl font-bold text-center">聖地メモはありません。</p>
-    </div>
-  <% end %>
-</div>
+<div class="mb-24">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-4">
+    <% if @seichi_memos.any? %>
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+        <% @seichi_memos.each do |seichi_memo| %>
+          <%= render "seichi_memos/seichi_memo", seichi_memo: seichi_memo %>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="flex justify-center items-center w-full py-10">
+        <p class="text-gray-600 text-xl font-bold text-center">聖地メモはありません。</p>
+      </div>
+    <% end %>
+  </div>
 
-<!-- ページネーション -->
-<div class="flex justify-center mt-4">
-  <%= paginate @seichi_memos %>
+  <!-- ページネーション -->
+  <div class="flex justify-center mt-4">
+    <%= paginate @seichi_memos %>
+  </div>
 </div>

--- a/app/views/seichi_memos/show.html.erb
+++ b/app/views/seichi_memos/show.html.erb
@@ -6,7 +6,7 @@
 <% content_for :og_title, @seichi_memo.title %>
 <% content_for :og_description, truncate(@seichi_memo.body, length: 100) %>
 
-<div class="px-3 sm:px-6 md:px-8 my-6">
+<div class="px-3 sm:px-6 md:pt-8 mt-4 mb-24">
   <div class="max-w-3xl mx-auto px-4 sm:px-6 md:px-8 py-6 space-y-6 bg-white shadow-lg rounded-lg">
     <!-- タイトル -->
     <div class="flex justify-start items-center">

--- a/app/views/seichi_memos/show.html.erb
+++ b/app/views/seichi_memos/show.html.erb
@@ -14,7 +14,7 @@
     </div>
 
     <!-- ユーザー情報エリア -->
-    <div class="flex items-center justify-between px-2 py-2 mt-4">
+    <div class="flex items-center justify-between py-2 mt-4">
       <!-- 左：画像＋ユーザー名＋投稿日 -->
       <div class="flex items-center space-x-2">
         <%= link_to (@seichi_memo.user == current_user ? profile_path : user_path(@seichi_memo.user)), data: { action: "click->loading#show" } do %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -53,6 +53,7 @@
         <div class="divider"></div>
         <li><%= link_to root_path, data: { action: "click->loading#show" } do %><i class="fa-regular fa-circle-question"></i> アプリの使い方 <% end %></li>
         <li><%= link_to seichi_memos_path, data: { action: "click->loading#show" } do %><i class="fas fa-search"></i> 聖地メモ検索 <% end %></li>
+        <li><%= link_to maps_path, data: { action: "click->loading#show" } do %><i class="fa-solid fa-map-location-dot"></i> マップ検索<% end %></li>
       <% end %>
       <div class="divider"></div>
       <li><%= link_to '利用規約', terms_of_service_path, data: { action: "click->loading#show" } %></li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, t(".title")) %>
 
 <!-- 🔹 プロフィールカード -->
-<section class="px-4 py-10 sm:px-6 lg:px-8">
+<div class="px-4 py-10 sm:px-6 lg:px-8 mb-24">
   <div class="max-w-3xl mx-auto bg-white shadow-2xl rounded-3xl overflow-hidden p-6 sm:p-10 mb-12">
     <div class="flex flex-col items-center text-center space-y-5">
       <div class="relative">
@@ -46,4 +46,4 @@
       <p class="text-center text-gray-500">このユーザーの聖地メモはありません</p>
     <% end %>
   </div>
-</section>
+</div>


### PR DESCRIPTION
## 概要
1. 地図上の投稿のピンをクリックしてモーダルで表示される聖地メモの概要から詳細ページに遷移する際のローディングアニメーションの追加
2. 地図上の投稿のピンをクリックしてモーダルで表示される聖地メモの概要からからユーザープロフィールへ遷移する際のローディングアニメーションの追加
3. 未ログイン時のハンバーガーメニューにマップ検索のメニューを追加する
4. マップ検索のキーワード検索と現在地を取得するボタンのスタイルが画面外にはみ出ている問題修正
5.マップ検索画面のページ下部のスペース削除
## 実施内容

## 関連issue