### PR TITLE
Feature/#174 seichi memoモデルのテスト

### DIFF
--- a/app/models/seichi_memo.rb
+++ b/app/models/seichi_memo.rb
@@ -11,6 +11,10 @@ class SeichiMemo < ApplicationRecord
   mount_uploader :seichi_photo, SeichiPhotoUploader
   mount_uploader :scene_image, SceneImageUploader
 
+  #  🔹 バリデーション
+  validates :title, presence: true, length: { maximum: 30 }
+  validates :body, presence: true, length: { maximum: 500 }
+
   # ransackで許可するテーブル
   def self.ransackable_attributes(auth_object = nil)
     %w[title created_at]

--- a/spec/factories/animes.rb
+++ b/spec/factories/animes.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :anime do
+    title { "title" }
+    official_site_url { "https://example.com" }
+    image_url { nil }
+  end
+end

--- a/spec/factories/places.rb
+++ b/spec/factories/places.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :place do
+    name { "秋葉原" }
+    address { "東京都千代田区" }
+    postal_code { "100-0001" }
+    latitude { 35.6895 }
+    longitude { 139.6917 }
+  end
+end

--- a/spec/factories/seichi_memos.rb
+++ b/spec/factories/seichi_memos.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :seichi_memo do
+    title { "title" }
+    body  { "body" }
+
+    # アソシエーション
+    association :user
+    association :anime
+    association :place
+  end
+end

--- a/spec/factories/seichi_memos.rb
+++ b/spec/factories/seichi_memos.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :seichi_memo do
     title { "title" }
     body  { "body" }
+    scene_image { nil }
+    seichi_photo { nil }
 
     # アソシエーション
     association :user

--- a/spec/models/seichi_memo_spec.rb
+++ b/spec/models/seichi_memo_spec.rb
@@ -3,30 +3,30 @@ require 'rails_helper'
 RSpec.describe SeichiMemo, type: :model do
   describe 'バリデーションチェック' do
     it '設定したすべてのバリデーションが機能しているか' do
-      seichi_memo = FactoryBot.build(:seichi_memo)
+      seichi_memo = build(:seichi_memo)
       expect(seichi_memo).to be_valid
     end
 
     it 'titleが空だと無効になる' do
-      seichi_memo = FactoryBot.build(:seichi_memo, title: '')
+      seichi_memo = build(:seichi_memo, title: '')
       expect(seichi_memo).to be_invalid
       expect(seichi_memo.errors[:title]).to include('を入力してください')
     end
 
     it 'titleが31文字以上だと無効になる' do
-      seichi_memo = FactoryBot.build(:seichi_memo, title: 'あ' * 31)
+      seichi_memo = build(:seichi_memo, title: 'a' * 31)
       expect(seichi_memo).to be_invalid
       expect(seichi_memo.errors[:title]).to include('は30文字以内で入力してください')
     end
 
     it 'bodyが空だと無効になる' do
-      seichi_memo = FactoryBot.build(:seichi_memo, body: '')
+      seichi_memo = build(:seichi_memo, body: '')
       expect(seichi_memo).to be_invalid
       expect(seichi_memo.errors[:body]).to include('を入力してください')
     end
 
     it 'bodyが501文字以上だと無効になる' do
-      seichi_memo = FactoryBot.build(:seichi_memo, body: 'あ' * 501)
+      seichi_memo = build(:seichi_memo, body: 'a' * 501)
       expect(seichi_memo).to be_invalid
       expect(seichi_memo.errors[:body]).to include('は500文字以内で入力してください')
     end

--- a/spec/models/seichi_memo_spec.rb
+++ b/spec/models/seichi_memo_spec.rb
@@ -1,5 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe SeichiMemo, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーションチェック' do
+    it '設定したすべてのバリデーションが機能しているか' do
+      seichi_memo = FactoryBot.build(:seichi_memo)
+      expect(seichi_memo).to be_valid
+    end
+
+    it 'titleが空だと無効になる' do
+      seichi_memo = FactoryBot.build(:seichi_memo, title: '')
+      expect(seichi_memo).to be_invalid
+      expect(seichi_memo.errors[:title]).to include('を入力してください')
+    end
+
+    it 'titleが31文字以上だと無効になる' do
+      seichi_memo = FactoryBot.build(:seichi_memo, title: 'あ' * 31)
+      expect(seichi_memo).to be_invalid
+      expect(seichi_memo.errors[:title]).to include('は30文字以内で入力してください')
+    end
+
+    it 'bodyが空だと無効になる' do
+      seichi_memo = FactoryBot.build(:seichi_memo, body: '')
+      expect(seichi_memo).to be_invalid
+      expect(seichi_memo.errors[:body]).to include('を入力してください')
+    end
+
+    it 'bodyが501文字以上だと無効になる' do
+      seichi_memo = FactoryBot.build(:seichi_memo, body: 'あ' * 501)
+      expect(seichi_memo).to be_invalid
+      expect(seichi_memo.errors[:body]).to include('は500文字以内で入力してください')
+    end
+  end
 end


### PR DESCRIPTION
## 概要
Seichi_memoモデル周りのモデルスペックのテストコードを作成します。
## 実施内容
![image](https://github.com/user-attachments/assets/d2705093-eafb-4e56-bd19-e46f378d9da7)

## 関連issue
#174 seichi memoモデルのテスト